### PR TITLE
feat(web): cache overview.json + SSR hero chart (zero-wait first paint)

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -22,3 +22,8 @@
 # so a returning visitor never renders against a stale shard list.
 /data/manifest.json
   Cache-Control: public, max-age=0, must-revalidate
+
+# The landing's precomputed aggregate. Stable name, changes daily — cache like the
+# shards so repeat visits paint from disk instead of a revalidation round-trip.
+/data/overview.json
+  Cache-Control: public, max-age=3600, must-revalidate

--- a/web/src/lib/echartsSSR.ts
+++ b/web/src/lib/echartsSSR.ts
@@ -1,0 +1,60 @@
+// Server-only ECharts, SVG renderer, for build-time SSR of the hero (price-trends)
+// chart. Imported ONLY from index.astro's frontmatter, so the SVGRenderer never
+// ships to the client (the client uses the canvas build in ./echarts).
+//
+// The option here mirrors renderTrends() in index.astro for the default 'lease'
+// lens, so the inlined SVG matches what the canvas chart draws after hydration.
+import * as echarts from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent, LegendComponent } from 'echarts/components';
+import { SVGRenderer } from 'echarts/renderers';
+import { baseOption, palette, axisLabel, splitLine, axisLine } from './echartsTheme';
+import { moneyShort } from './format';
+
+echarts.use([LineChart, GridComponent, LegendComponent, SVGRenderer]);
+
+type TrendRow = { quarter: string; series: string; v: number };
+
+/** Render the price-trends line chart to a standalone SVG string (no JS, no fetch). */
+export function trendsSVG(rows: TrendRow[], width: number, height: number): string {
+  const quarters = [...new Set(rows.map((r) => r.quarter))].sort();
+  const seriesNames = [...new Set(rows.map((r) => r.series))].sort();
+  const byKey = new Map(rows.map((r) => [r.series + '|' + r.quarter, Number(r.v)]));
+
+  const series = seriesNames.map((name) => ({
+    name,
+    type: 'line' as const,
+    smooth: true,
+    showSymbol: false,
+    data: quarters.map((qtr) => {
+      const v = byKey.get(name + '|' + qtr);
+      return v == null ? null : Math.round(v);
+    }),
+  }));
+
+  // ssr:true + animation:false are required for a deterministic, static render.
+  const chart = echarts.init(null, null, { renderer: 'svg', ssr: true, width, height });
+  chart.setOption({
+    ...baseOption(),
+    color: palette,
+    animation: false,
+    legend: { top: 0, right: 0, type: 'scroll', textStyle: { fontSize: 12 }, icon: 'roundRect' },
+    grid: { left: 66, right: 24, top: 40, bottom: 46, containLabel: false },
+    xAxis: {
+      type: 'category', data: quarters, boundaryGap: false,
+      axisLabel: { ...axisLabel, interval: Math.ceil(quarters.length / 8) },
+      axisLine, axisTick: { show: false },
+    },
+    yAxis: {
+      type: 'value', scale: true,
+      axisLabel: { ...axisLabel, formatter: (v: number) => moneyShort(v) },
+      splitLine,
+    },
+    series,
+  });
+  const svg = chart.renderToSVGString();
+  chart.dispose();
+  // Let CSS stretch it to the fluid container width (it's a brief placeholder,
+  // replaced by the canvas chart on hydration) instead of letterboxing.
+  return svg.replace('<svg ', '<svg preserveAspectRatio="none" ');
+}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,6 +1,22 @@
 ---
 import Base from '../layouts/Base.astro';
+import { trendsSVG } from '../lib/echartsSSR';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 const base = import.meta.env.BASE_URL;
+
+// SSR the hero chart to inline SVG so it paints instantly — no JS, no fetch. The
+// client swaps in the interactive canvas chart after hydration. Falls back to a
+// client-only render if overview.json hasn't been generated yet (e.g. fresh clone).
+let heroSVG = '';
+try {
+  const path = fileURLToPath(new URL('../../public/data/overview.json', import.meta.url));
+  const ov = JSON.parse(fs.readFileSync(path, 'utf8'));
+  heroSVG = trendsSVG(ov.trends.lease, 1040, 380);
+} catch {
+  heroSVG = '';
+}
 ---
 
 <Base active="Resale Visualizations" title="Resale Visualizations — HDB Kaki">
@@ -32,7 +48,7 @@ const base = import.meta.env.BASE_URL;
     </div>
     <div class="card chart-card">
       <div class="chart-head"><div class="chart-title" id="trend-title">Median resale price by lease band</div></div>
-      <div id="chart-trends" class="chart-box"></div>
+      <div id="chart-trends" class="chart-box" set:html={heroSVG}></div>
     </div>
 
     <!-- 02 · DISTRIBUTION -->
@@ -77,6 +93,8 @@ const base = import.meta.env.BASE_URL;
 
 <style>
   .chart-box { width: 100%; height: 380px; }
+  /* Stretch the SSR placeholder SVG to fill the box until the canvas chart hydrates. */
+  #chart-trends svg { width: 100% !important; height: 100% !important; display: block; }
   #chart-scatter, #chart-buckets { height: 320px; }
 </style>
 
@@ -96,7 +114,9 @@ const base = import.meta.env.BASE_URL;
   const q = (id: string) => document.getElementById(id)!;
 
   // ---- 01 price trends (with lens toggle) ----
-  const trendChart = echarts.init(q('chart-trends'));
+  // Initialised in boot(), after data loads, so the SSR placeholder SVG stays
+  // visible until we can draw the interactive canvas chart in one step.
+  let trendChart: ReturnType<typeof echarts.init> | undefined;
   const trendTitle: Record<string, string> = {
     lease: 'Median resale price by lease band',
     flat: 'Median resale price by flat type',
@@ -104,6 +124,7 @@ const base = import.meta.env.BASE_URL;
   };
 
   function renderTrends(mode: string) {
+    if (!OV || !trendChart) return;
     q('trend-title').textContent = trendTitle[mode];
     const rows = OV.trends[mode];
     const quarters = [...new Set(rows.map((r) => r.quarter))].sort();
@@ -241,6 +262,9 @@ const base = import.meta.env.BASE_URL;
       if (!r.ok) throw new Error(`overview.json ${r.status}`);
       return r.json();
     });
+    // Replace the SSR placeholder SVG with the interactive canvas chart in one step.
+    q('chart-trends').innerHTML = '';
+    trendChart = echarts.init(q('chart-trends'));
     renderTrends('lease');
     renderBox();
     renderLease();
@@ -248,7 +272,7 @@ const base = import.meta.env.BASE_URL;
   }
   boot();
   window.addEventListener('resize', () => {
-    trendChart.resize();
+    trendChart?.resize();
     echarts.getInstanceByDom(q('chart-box'))?.resize();
     echarts.getInstanceByDom(q('chart-scatter'))?.resize();
     echarts.getInstanceByDom(q('chart-buckets'))?.resize();


### PR DESCRIPTION
## What

The two follow-ups noted in #6: cache `overview.json` for repeat visits, and SSR the hero chart to inline SVG for a literal zero-wait first paint.

## Commits

1. **`feat(web): cache overview.json for repeat visits`** — the landing's aggregate was served with Cloudflare's default `Cache-Control: max-age=0, must-revalidate` (confirmed against production), so every visit paid a revalidation round-trip. Adds a `_headers` rule (`max-age=3600, must-revalidate`) matching the shard policy — non-overlapping with the existing rules.

2. **`perf(web): SSR the hero chart to inline SVG`** — renders the price-trends chart to an SVG string at build time and inlines it in the landing HTML, so it's visible at first paint with no JS and no fetch. The client swaps in the interactive canvas chart on hydration (one step, no flash, no leftover SVG). The SVG renderer lives in a server-only `lib/echartsSSR.ts` and never ships to the client. Gracefully falls back to client-only render if `overview.json` is absent at build.

## Verification

- **Zero-JS paint:** with JavaScript disabled, `#chart-trends` contains the rendered SVG (20 paths). FCP ~140 ms, hero chart included.
- **Clean hydration:** with JS on, the hero has 1 canvas and 0 leftover SVG; all 4 charts render; recent table populated; zero console errors.
- **No client bloat:** `SVGRenderer` appears 0 times in the client bundle and the ECharts chunk hash is byte-identical to before — the server-only import added nothing to the client.
- Build clean; existing behaviour (data, other charts) unchanged.

## Notes

- CI needs no change — `deploy.yaml` runs `emit_web.py` (so `overview.json` exists at build) then builds, which is where the SSR runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
