### PR TITLE
Serve site on app.hdb-kaki.workers.dev

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
 
-// Static output (default). Host-agnostic build → deployable to Cloudflare Pages,
-// GitHub Pages, etc. See wireframes/REBUILD_PLAN.md.
+// Static output (default). Host-agnostic build → deployable to Cloudflare
+// Workers, GitHub Pages, etc. See wireframes/REBUILD_PLAN.md.
 export default defineConfig({
-  site: 'https://hdb-kaki.pages.dev',
+  site: 'https://app.hdb-kaki.workers.dev',
 });

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -4,7 +4,9 @@
 # no `main` script, requests are answered purely from the asset store — the
 # `_headers` file in ./dist still drives our per-asset Cache-Control policy.
 # Deploy locally or from CI with:  wrangler deploy
-name = "hdb-kaki"
+# Worker name is the first URL label: app.<account-subdomain>.workers.dev
+# (account subdomain is "hdb-kaki"), i.e. https://app.hdb-kaki.workers.dev
+name = "app"
 compatibility_date = "2026-07-17"
 
 [assets]


### PR DESCRIPTION
Follow-up to the Pages→Workers migration (#9).

The account's `workers.dev` subdomain is now `hdb-kaki`, so:

- **`web/wrangler.toml`** — rename the Worker `hdb-kaki` → `app`, producing the URL **`https://app.hdb-kaki.workers.dev`**.
- **`web/astro.config.mjs`** — set `site` to that URL (canonical/OG URLs).

Verified: `bun run build` ✅, `wrangler deploy --dry-run` ✅ (reads 35 files from `./dist`).

### After merge / deploy
- The rename creates a **new** Worker `app`; the old `hdb-kaki` Worker becomes orphaned — delete it in the dashboard (no traffic/state on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)