### PR TITLE
perf(web): self-host DuckDB-WASM engine, brotli-compressed same-origin

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,9 +1,14 @@
 node_modules/
 dist/
 .astro/
+.wrangler/
 
 # Generated data artifacts (year-sharded parquet + manifest). Produced by
 # `webapp/update/emit_web.py` from data/df.parquet — regenerated in CI on every
 # deploy, so we keep them out of git history rather than commit ~3-4MB daily.
 # For local dev, run once:  uv run --with polars webapp/update/emit_web.py
 public/data/
+
+# Brotli-compressed DuckDB-WASM engine, staged from node_modules by
+# scripts/compress-duckdb.mjs on every build. Regenerated, so not committed.
+public/duckdb/

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,7 +1,44 @@
 import { defineConfig } from 'astro/config';
+import { readFileSync } from 'node:fs';
+
+// Read straight from the installed package's manifest so the version can never
+// drift from what upload-duckdb-r2.mjs pushes to R2. Exposed to client code as
+// import.meta.env.PUBLIC_DUCKDB_VERSION, which src/lib/duckdbBundle.ts uses to
+// build the version-pinned /duckdb/<version>/ URLs.
+const duckdbVersion = JSON.parse(
+  readFileSync(new URL('./node_modules/@duckdb/duckdb-wasm/package.json', import.meta.url), 'utf8'),
+).version;
+
+// `astro dev` doesn't run src/worker.ts, so /duckdb/* would 404 locally. Mirror the
+// Worker's jsDelivr fallback here so the engine loads in dev exactly as it does in
+// production before R2 is populated. Key format matches: "/duckdb/<version>/<file>".
+const duckdbDevFallback = {
+  name: 'duckdb-dev-fallback',
+  configureServer(server) {
+    server.middlewares.use('/duckdb', (req, res) => {
+      const key = (req.url ?? '').replace(/^\//, '').split('?')[0]; // "<version>/<file>"
+      const slash = key.indexOf('/');
+      if (slash === -1) {
+        res.statusCode = 404;
+        return res.end('Not found');
+      }
+      const version = key.slice(0, slash);
+      const file = key.slice(slash + 1);
+      res.statusCode = 302;
+      res.setHeader('Location', `https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@${version}/dist/${file}`);
+      res.end();
+    });
+  },
+};
 
 // Static output (default). Host-agnostic build → deployable to Cloudflare
 // Workers, GitHub Pages, etc. See wireframes/REBUILD_PLAN.md.
 export default defineConfig({
   site: 'https://app.hdb-kaki.workers.dev',
+  vite: {
+    define: {
+      'import.meta.env.PUBLIC_DUCKDB_VERSION': JSON.stringify(duckdbVersion),
+    },
+    plugins: [duckdbDevFallback],
+  },
 });

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "node scripts/compress-duckdb.mjs && astro build",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,12 +1,22 @@
 # Cloudflare Pages headers. https://developers.cloudflare.com/pages/configuration/headers/
 #
-# NOTE: deliberately NO Cross-Origin-Embedder-Policy / COOP here. DuckDB-WASM loads
-# its engine from the jsDelivr CDN and Leaflet pulls OSM tiles cross-origin; enabling
-# COEP: require-corp would block both. The single-threaded WASM bundle we use does
-# not need cross-origin isolation.
+# NOTE: deliberately NO Cross-Origin-Embedder-Policy / COOP here. Leaflet pulls OSM
+# tiles cross-origin, so COEP: require-corp would break them. The single-threaded WASM
+# bundle we use does not need cross-origin isolation.
+#
+# The DuckDB .wasm at /duckdb/*.wasm is served by src/worker.ts (brotli-compressed
+# asset re-served with Content-Encoding: br), which sets its own immutable caching —
+# _headers do not apply to Worker responses. The sibling .worker.js files ARE served
+# directly by the asset store, so the /duckdb/* rule below pins their caching.
 
 # Astro emits content-hashed filenames under /_astro/ — safe to cache forever.
 /_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# DuckDB engine files (version-pinned path, see scripts/compress-duckdb.mjs). Only
+# the directly-served ones (.worker.js) pick this up; the Worker-served .wasm sets
+# its own equivalent header.
+/duckdb/*
   Cache-Control: public, max-age=31536000, immutable
 
 # Data shard filenames are stable but their contents change on each daily ETL run,

--- a/web/scripts/compress-duckdb.mjs
+++ b/web/scripts/compress-duckdb.mjs
@@ -1,0 +1,37 @@
+// Stage the DuckDB-WASM engine into public/duckdb/<version>/ for the build.
+//
+// The raw .wasm modules (34-39 MiB) exceed Cloudflare's 25 MiB static-asset cap, so
+// we brotli-compress them to ~4.4 MiB `<file>.br` — comfortably under the cap and an
+// ~8x smaller download. src/worker.ts serves those back with Content-Encoding: br.
+// The small worker .js files ship as-is (Cloudflare compresses them at the edge).
+//
+// Runs as part of `bun run build` (see package.json). The output is gitignored and
+// regenerated each build, so it always matches the pinned @duckdb/duckdb-wasm version.
+import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from 'node:fs';
+import { brotliCompressSync, constants } from 'node:zlib';
+import { join } from 'node:path';
+
+const DIST = 'node_modules/@duckdb/duckdb-wasm/dist';
+const version = JSON.parse(readFileSync('node_modules/@duckdb/duckdb-wasm/package.json', 'utf8')).version;
+const outDir = join('public/duckdb', version);
+mkdirSync(outDir, { recursive: true });
+
+// Max quality (q11): compression is a one-time build cost, but the result is cached
+// immutably in the browser, so the smaller download pays off on every first visit.
+const wasm = ['duckdb-eh.wasm', 'duckdb-mvp.wasm'];
+for (const f of wasm) {
+  const raw = readFileSync(join(DIST, f));
+  const br = brotliCompressSync(raw, {
+    params: {
+      [constants.BROTLI_PARAM_QUALITY]: 11,
+      [constants.BROTLI_PARAM_SIZE_HINT]: raw.length,
+    },
+  });
+  writeFileSync(join(outDir, `${f}.br`), br);
+  console.log(`brotli ${f}: ${(raw.length / 1048576).toFixed(1)} → ${(br.length / 1048576).toFixed(1)} MiB`);
+}
+
+const workers = ['duckdb-browser-eh.worker.js', 'duckdb-browser-mvp.worker.js'];
+for (const f of workers) copyFileSync(join(DIST, f), join(outDir, f));
+
+console.log(`DuckDB-WASM ${version} staged → ${outDir}`);

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -2,6 +2,7 @@
 // Lazily boots the WASM engine, registers every shard from manifest.json, and
 // exposes a typed query() helper. Runs entirely in the browser — no backend.
 import * as duckdb from '@duckdb/duckdb-wasm';
+import { duckdbBase } from './duckdbBundle';
 
 export interface Manifest {
   lastUpdated: string | null;
@@ -25,8 +26,14 @@ export function getManifest(): Promise<Manifest> {
 }
 
 async function boot(): Promise<duckdb.AsyncDuckDBConnection> {
-  const bundles = duckdb.getJsDelivrBundles();
-  const bundle = await duckdb.selectBundle(bundles);
+  // Self-hosted engine served same-origin from R2 via src/worker.ts (see
+  // src/lib/duckdbBundle.ts). selectBundle picks eh vs. mvp from browser features;
+  // both are absolute URLs so the blob worker's importScripts resolves them.
+  const dir = new URL(duckdbBase(), window.location.href).href;
+  const bundle = await duckdb.selectBundle({
+    mvp: { mainModule: `${dir}duckdb-mvp.wasm`, mainWorker: `${dir}duckdb-browser-mvp.worker.js` },
+    eh: { mainModule: `${dir}duckdb-eh.wasm`, mainWorker: `${dir}duckdb-browser-eh.worker.js` },
+  });
   const workerUrl = URL.createObjectURL(
     new Blob([`importScripts("${bundle.mainWorker}");`], { type: 'text/javascript' }),
   );

--- a/web/src/lib/duckdbBundle.ts
+++ b/web/src/lib/duckdbBundle.ts
@@ -1,0 +1,23 @@
+// Single source of truth for the self-hosted DuckDB-WASM bundle URLs.
+//
+// The engine (~34 MiB of .wasm plus its worker) is copied out of node_modules
+// into public/duckdb/<version>/ at build time by scripts/copy-duckdb.mjs and
+// served from our own origin — so Cloudflare caches it immutably and pages can
+// prefetch it, instead of streaming it cross-origin from jsDelivr. The version is
+// injected from the installed @duckdb/duckdb-wasm package by astro.config.mjs
+// (PUBLIC_DUCKDB_VERSION), so this path can never drift from what was copied.
+const VERSION = import.meta.env.PUBLIC_DUCKDB_VERSION;
+
+/** Root-relative dir holding this version's bundle files, e.g. `/duckdb/1.29.0/`. */
+export function duckdbBase(base: string = import.meta.env.BASE_URL): string {
+  return `${base}duckdb/${VERSION}/`;
+}
+
+/**
+ * URL of the exception-handling wasm module — the bundle selectBundle() picks on
+ * every browser we support. Pages `<link rel="prefetch">` this to warm the HTTP
+ * cache before the first query spins up the engine.
+ */
+export function ehWasmUrl(base?: string): string {
+  return `${duckdbBase(base)}duckdb-eh.wasm`;
+}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -271,6 +271,23 @@ try {
     renderRecent();
   }
   boot();
+
+  // Pre-warm the DuckDB engine while the visitor reads the landing, so the first
+  // click into an interactive page skips the cold start. Full warm (not just a byte
+  // fetch): it downloads + instantiates, populating both the HTTP cache and the
+  // browser's compiled-wasm code cache, which carries across the navigation. Dynamic-
+  // imported to stay out of the landing bundle and deferred to idle so it never
+  // competes with the landing's own render. Skipped under Save-Data.
+  warmEngineWhenIdle();
+  function warmEngineWhenIdle() {
+    if ((navigator as any).connection?.saveData) return;
+    const idle: (cb: () => void) => void =
+      (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
+    idle(() => {
+      import('../lib/db').then((m) => m.prefetch()).catch(() => {});
+    });
+  }
+
   window.addEventListener('resize', () => {
     trendChart?.resize();
     echarts.getInstanceByDom(q('chart-box'))?.resize();

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -1,8 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
+import { ehWasmUrl } from '../lib/duckdbBundle';
 ---
 
 <Base active="My Flat Insights" title="My Flat Insights — HDB Kaki">
+  <!-- This page auto-computes a default valuation on load; warm the same-origin
+       DuckDB engine in parallel with parse so it isn't blocked on a cold fetch. -->
+  <link slot="head" rel="prefetch" href={ehWasmUrl()} as="fetch" />
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> New · Personalised</span>
@@ -231,6 +235,11 @@ import Base from '../layouts/Base.astro';
     if (!_db) _db = import('../lib/db');
     return (await _db).query<T>(sql);
   };
+  // This page auto-computes a default valuation on load, so start warming the engine
+  // now — overlapping the WASM download with DOM wiring instead of waiting for the
+  // first query. (Idempotent: primes the same _db the query wrapper reuses.)
+  _db = import('../lib/db');
+  _db.then((m) => m.prefetch()).catch(() => {});
   import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
 
   const $ = (id: string) => document.getElementById(id)!;

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -1,8 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
+import { ehWasmUrl } from '../lib/duckdbBundle';
 ---
 
 <Base active="PSF Trends" title="PSF Trends — HDB Kaki">
+  <!-- This page auto-runs a query on load; warm the same-origin DuckDB engine in
+       parallel with parse so the first query isn't blocked on a cold ~34 MiB fetch. -->
+  <link slot="head" rel="prefetch" href={ehWasmUrl()} as="fetch" />
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> Price per Square Foot</span>
@@ -69,6 +73,11 @@ import Base from '../layouts/Base.astro';
     if (!_db) _db = import('../lib/db');
     return (await _db).query<T>(sql);
   };
+  // This page renders a default view on load, so start warming the engine now —
+  // overlapping the WASM download with DOM wiring instead of waiting for the first
+  // query. (Idempotent: primes the same _db the query wrapper reuses.)
+  _db = import('../lib/db');
+  _db.then((m) => m.prefetch()).catch(() => {});
   import { baseOption, axisLabel, splitLine, axisLine, ink2, line as lineCol, red } from '../lib/echartsTheme';
   import { money, psf as fpsf, titleCase } from '../lib/format';
 

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -1,8 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
+import { ehWasmUrl } from '../lib/duckdbBundle';
 ---
 
 <Base active="Town Analysis" title="Town Analysis — HDB Kaki">
+  <!-- This page auto-runs a query on load; warm the same-origin DuckDB engine in
+       parallel with parse so the first query isn't blocked on a cold ~34 MiB fetch. -->
+  <link slot="head" rel="prefetch" href={ehWasmUrl()} as="fetch" />
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> Explore by Town</span>
@@ -99,6 +103,11 @@ import Base from '../layouts/Base.astro';
     if (!_db) _db = import('../lib/db');
     return (await _db).query<T>(sql);
   };
+  // This page renders a default view on load, so start warming the engine now —
+  // overlapping the WASM download with DOM wiring instead of waiting for the first
+  // query. (Idempotent: primes the same _db the query wrapper reuses.)
+  _db = import('../lib/db');
+  _db.then((m) => m.prefetch()).catch(() => {});
   import { baseOption, palette, axisLabel, splitLine, axisLine, ink3, ink } from '../lib/echartsTheme';
   import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
 

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -3,11 +3,16 @@
 //
 // The raw engine is 34-39 MiB — over Cloudflare's 25 MiB static-asset cap, so it
 // can't ship as a plain asset. Instead scripts/compress-duckdb.mjs brotli-compresses
-// it to ~4.4 MiB (well under the cap) and ships THAT as `<file>.wasm.br`. This Worker
-// serves it back with the `Content-Encoding: br` and `Content-Type: application/wasm`
-// that WebAssembly.instantiateStreaming needs — set in code, so we don't depend on
-// Cloudflare's asset layer honouring a hand-rolled Content-Encoding. See
-// src/lib/duckdbBundle.ts for the URL scheme.
+// it to ~4.5 MiB (well under the cap) and ships THAT as `<file>.wasm.br`. This Worker
+// serves it back with the `Content-Encoding: br` + `Content-Type: application/wasm`
+// that WebAssembly.instantiateStreaming needs, using `encodeBody: "manual"` so the
+// runtime treats the body as already-encoded and doesn't re-compress it.
+//
+// NB: we deliberately do NOT run these through the Cache API. The Cache API doesn't
+// preserve Content-Encoding / the encodeBody flag, so a cached copy gets served with
+// the encoding stripped — the browser then hands raw brotli to WebAssembly and it
+// fails to compile. Serving fresh from ASSETS every time keeps the encoding intact
+// (ASSETS reads are edge-local and cheap); the browser still caches immutably below.
 //
 // Every other request is a static asset served before this Worker runs; we only see
 // the engine requests and 404 misses, which we forward to env.ASSETS untouched.
@@ -16,52 +21,35 @@ interface Env {
   ASSETS: { fetch(request: Request): Promise<Response> };
 }
 
-// Minimal shapes for the Workers-runtime bits the DOM lib doesn't declare, so we
-// avoid pulling in @cloudflare/workers-types for a ~70-line Worker.
-interface ExecutionContext {
-  waitUntil(promise: Promise<unknown>): void;
-}
-// `encodeBody: "manual"` tells the runtime the body is ALREADY in its final encoding
-// — don't re-compress it. Without this, Workers gzip-wraps our brotli bytes and the
-// browser hands garbage to WebAssembly. Not in the DOM lib's ResponseInit.
+// `encodeBody: "manual"` (a Workers ResponseInit extension not in the DOM lib) tells
+// the runtime the body is already in its final encoding — don't compress it again.
 interface CfResponseInit extends ResponseInit {
   encodeBody?: 'automatic' | 'manual';
 }
 
-// no-transform belts-and-braces against any further edge recompression.
+// no-transform belts-and-braces against any edge recompression of the wasm.
 const IMMUTABLE = 'public, max-age=31536000, immutable, no-transform';
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     if (url.pathname.startsWith('/duckdb/')) {
-      return serveEngine(request, url, env, ctx);
+      return serveEngine(request, url, env);
     }
     return env.ASSETS.fetch(request);
   },
 };
 
-// Serve `/duckdb/<version>/<file>`, cached at the edge and immutably in the browser.
-// `.wasm` comes from the brotli-compressed `<file>.br` asset; workers/other files are
-// small and pass through as-is. Missing assets fall back to jsDelivr so the engine
-// still loads if a build ever skipped the compress step.
-async function serveEngine(
-  request: Request,
-  url: URL,
-  env: Env,
-  ctx: ExecutionContext,
-): Promise<Response> {
-  const cache = (caches as unknown as { default: Cache }).default;
-  const hit = await cache.match(request);
-  if (hit) return hit;
-
-  let res: Response;
+// `.wasm` comes from the brotli-compressed `<file>.br` asset, re-served with the
+// right encoding/type. Other engine files (workers) are small and pass through.
+// Missing assets fall back to jsDelivr so the engine still loads if a build ever
+// skipped the compress step (also covers `wrangler dev` against an empty ./dist).
+async function serveEngine(request: Request, url: URL, env: Env): Promise<Response> {
   if (url.pathname.endsWith('.wasm')) {
-    // Fetch the pre-compressed twin with a bare GET so the asset layer returns the
-    // raw brotli bytes rather than trying to re-encode them.
+    // Bare GET so the asset layer returns the raw brotli bytes rather than re-encoding.
     const asset = await env.ASSETS.fetch(new Request(`${url.origin}${url.pathname}.br`));
     if (!asset.ok) return jsdelivrFallback(url.pathname);
-    res = new Response(asset.body, {
+    return new Response(asset.body, {
       encodeBody: 'manual',
       headers: {
         'Content-Type': 'application/wasm',
@@ -69,16 +57,13 @@ async function serveEngine(
         'Cache-Control': IMMUTABLE,
       },
     } as CfResponseInit);
-  } else {
-    const asset = await env.ASSETS.fetch(request);
-    if (!asset.ok) return jsdelivrFallback(url.pathname);
-    const headers = new Headers(asset.headers); // mutable copy; asset's are guarded
-    headers.set('Cache-Control', IMMUTABLE);
-    res = new Response(asset.body, { status: asset.status, headers });
   }
 
-  ctx.waitUntil(cache.put(request, res.clone()));
-  return res;
+  const asset = await env.ASSETS.fetch(request);
+  if (!asset.ok) return jsdelivrFallback(url.pathname);
+  const headers = new Headers(asset.headers); // mutable copy; asset's are guarded
+  headers.set('Cache-Control', IMMUTABLE);
+  return new Response(asset.body, { status: asset.status, headers });
 }
 
 // "/duckdb/<version>/<file>" mirrors the npm layout -> jsDelivr's

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -1,0 +1,94 @@
+// Entry Worker for the otherwise assets-only site. It exists for ONE reason: to
+// serve the DuckDB-WASM engine at same-origin `/duckdb/<version>/<file>`.
+//
+// The raw engine is 34-39 MiB — over Cloudflare's 25 MiB static-asset cap, so it
+// can't ship as a plain asset. Instead scripts/compress-duckdb.mjs brotli-compresses
+// it to ~4.4 MiB (well under the cap) and ships THAT as `<file>.wasm.br`. This Worker
+// serves it back with the `Content-Encoding: br` and `Content-Type: application/wasm`
+// that WebAssembly.instantiateStreaming needs — set in code, so we don't depend on
+// Cloudflare's asset layer honouring a hand-rolled Content-Encoding. See
+// src/lib/duckdbBundle.ts for the URL scheme.
+//
+// Every other request is a static asset served before this Worker runs; we only see
+// the engine requests and 404 misses, which we forward to env.ASSETS untouched.
+
+interface Env {
+  ASSETS: { fetch(request: Request): Promise<Response> };
+}
+
+// Minimal shapes for the Workers-runtime bits the DOM lib doesn't declare, so we
+// avoid pulling in @cloudflare/workers-types for a ~70-line Worker.
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+// `encodeBody: "manual"` tells the runtime the body is ALREADY in its final encoding
+// — don't re-compress it. Without this, Workers gzip-wraps our brotli bytes and the
+// browser hands garbage to WebAssembly. Not in the DOM lib's ResponseInit.
+interface CfResponseInit extends ResponseInit {
+  encodeBody?: 'automatic' | 'manual';
+}
+
+// no-transform belts-and-braces against any further edge recompression.
+const IMMUTABLE = 'public, max-age=31536000, immutable, no-transform';
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname.startsWith('/duckdb/')) {
+      return serveEngine(request, url, env, ctx);
+    }
+    return env.ASSETS.fetch(request);
+  },
+};
+
+// Serve `/duckdb/<version>/<file>`, cached at the edge and immutably in the browser.
+// `.wasm` comes from the brotli-compressed `<file>.br` asset; workers/other files are
+// small and pass through as-is. Missing assets fall back to jsDelivr so the engine
+// still loads if a build ever skipped the compress step.
+async function serveEngine(
+  request: Request,
+  url: URL,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const cache = (caches as unknown as { default: Cache }).default;
+  const hit = await cache.match(request);
+  if (hit) return hit;
+
+  let res: Response;
+  if (url.pathname.endsWith('.wasm')) {
+    // Fetch the pre-compressed twin with a bare GET so the asset layer returns the
+    // raw brotli bytes rather than trying to re-encode them.
+    const asset = await env.ASSETS.fetch(new Request(`${url.origin}${url.pathname}.br`));
+    if (!asset.ok) return jsdelivrFallback(url.pathname);
+    res = new Response(asset.body, {
+      encodeBody: 'manual',
+      headers: {
+        'Content-Type': 'application/wasm',
+        'Content-Encoding': 'br',
+        'Cache-Control': IMMUTABLE,
+      },
+    } as CfResponseInit);
+  } else {
+    const asset = await env.ASSETS.fetch(request);
+    if (!asset.ok) return jsdelivrFallback(url.pathname);
+    const headers = new Headers(asset.headers); // mutable copy; asset's are guarded
+    headers.set('Cache-Control', IMMUTABLE);
+    res = new Response(asset.body, { status: asset.status, headers });
+  }
+
+  ctx.waitUntil(cache.put(request, res.clone()));
+  return res;
+}
+
+// "/duckdb/<version>/<file>" mirrors the npm layout -> jsDelivr's
+// "@<version>/dist/<file>". A 302 keeps the browser's fetch flowing; instantiation
+// follows redirects transparently.
+function jsdelivrFallback(pathname: string): Response {
+  const key = pathname.slice('/duckdb/'.length); // "<version>/<file>"
+  const slash = key.indexOf('/');
+  if (slash === -1) return new Response('Not found', { status: 404 });
+  const version = key.slice(0, slash);
+  const file = key.slice(slash + 1);
+  return Response.redirect(`https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@${version}/dist/${file}`, 302);
+}

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,15 +1,22 @@
 # Cloudflare Workers config for the HDB Kaki static site.
-# Assets-only Worker (no server code): Astro builds to ./dist, which the Workers
-# static-assets runtime serves directly from Cloudflare's edge. Because there is
-# no `main` script, requests are answered purely from the asset store — the
-# `_headers` file in ./dist still drives our per-asset Cache-Control policy.
+# Astro builds to ./dist, which the Workers static-assets runtime serves directly
+# from Cloudflare's edge; the `_headers` file in ./dist drives per-asset caching.
+# The tiny `main` Worker (src/worker.ts) exists only to serve the DuckDB-WASM engine
+# at /duckdb/* — the raw .wasm is too big for the 25 MiB static-asset cap, so it
+# ships brotli-compressed and the Worker adds the right Content-Encoding/-Type.
+# Assets are served before the Worker runs, so it only sees the engine requests and
+# 404 misses (which it forwards to ASSETS).
 # Deploy locally or from CI with:  wrangler deploy
 # Worker name is the first URL label: app.<account-subdomain>.workers.dev
 # (account subdomain is "hdb-kaki"), i.e. https://app.hdb-kaki.workers.dev
 name = "app"
+main = "src/worker.ts"
 compatibility_date = "2026-07-17"
 
 [assets]
 directory = "./dist"
+# Expose the asset store to the Worker so it can read the compressed engine + forward
+# non-engine requests.
+binding = "ASSETS"
 # Default html_handling ("auto-trailing-slash") maps /town-analysis ->
 # /town-analysis/index.html, matching Astro's directory-style static output.


### PR DESCRIPTION
## What

Serve the DuckDB-WASM engine from our own origin at `/duckdb/<version>/*`
instead of hot-linking jsDelivr, brotli-compressed to ~4.5 MiB.

## Why

The engine was loading cross-origin from jsDelivr — a third-party runtime
dependency on the critical query path, and cross-origin so we couldn't
prefetch it cleanly or control its caching.

The obvious fix (drop the `.wasm` in `dist/`) hits a wall: the raw engine is
34–39 MiB and Cloudflare's static-asset store caps individual files at 25 MiB.
Brotli sidesteps it — the engine compresses to 4.5 MiB (eh) / 5.0 MiB (mvp),
well under the cap and an ~8× smaller download.

## How

- `scripts/compress-duckdb.mjs` brotli-compresses the wasm at build time
  (q11) into `public/duckdb/<version>/`, run as part of `bun run build`.
- A small entry Worker (`src/worker.ts`) serves `/duckdb/*.wasm` from the
  `.br` asset with `Content-Encoding: br` + `Content-Type: application/wasm`.
  Uses `encodeBody: "manual"` so the runtime doesn't re-compress the already-
  brotli body. Falls back to jsDelivr if an asset is missing.
- Version is injected from the installed package (`PUBLIC_DUCKDB_VERSION`) so
  the served URLs can never drift from what was compressed.
- `boot()` switches off `getJsDelivrBundles()` onto the self-hosted URLs.
- Interactive pages `<link rel="prefetch">` the wasm and warm the engine on load.

## Deploy notes

No new secrets or infra — compression runs inside the existing `bun run build`
CI step. No R2, no billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
