### PR TITLE
perf(web): persist DuckDB engine across navigations via ClientRouter

### DIFF
--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/tokens.css';
 import '../styles/global.css';
+import { ClientRouter } from 'astro:transitions';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 
@@ -29,6 +30,10 @@ const {
       href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Public+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <!-- Client-side routing: swap the DOM instead of full reloads, so the DuckDB
+         engine (a module singleton in lib/db) stays warm across navigations.
+         Pages re-init their own UI on the astro:page-load event. -->
+    <ClientRouter />
     <!-- Per-page <head> extras, e.g. resource preloads. -->
     <slot name="head" />
   </head>

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -12,7 +12,6 @@ export interface Manifest {
   columns: string[];
 }
 
-let connPromise: Promise<duckdb.AsyncDuckDBConnection> | null = null;
 let manifestPromise: Promise<Manifest> | null = null;
 
 export function getManifest(): Promise<Manifest> {
@@ -56,8 +55,12 @@ async function boot(): Promise<duckdb.AsyncDuckDBConnection> {
 }
 
 function getConn(): Promise<duckdb.AsyncDuckDBConnection> {
-  if (!connPromise) connPromise = boot();
-  return connPromise;
+  // Cache the connection on window, not just a module variable, so the warm engine
+  // survives Astro client-side navigations (the module isn't re-run, but this also
+  // guards any accidental re-eval). Booting is expensive — one per session only.
+  const w = window as unknown as { __duckdbConn?: Promise<duckdb.AsyncDuckDBConnection> };
+  if (!w.__duckdbConn) w.__duckdbConn = boot();
+  return w.__duckdbConn;
 }
 
 /** Run SQL against the `resale` view and return plain JS row objects. */

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -117,6 +117,7 @@ try {
   // Initialised in boot(), after data loads, so the SSR placeholder SVG stays
   // visible until we can draw the interactive canvas chart in one step.
   let trendChart: ReturnType<typeof echarts.init> | undefined;
+  let active = false; // gates the shared resize/cleanup to when the landing is mounted
   const trendTitle: Record<string, string> = {
     lease: 'Median resale price by lease band',
     flat: 'Median resale price by flat type',
@@ -164,14 +165,6 @@ try {
       true,
     );
   }
-
-  document.querySelectorAll<HTMLButtonElement>('#trend-toggle .chip').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('#trend-toggle .chip').forEach((b) => b.classList.remove('on'));
-      btn.classList.add('on');
-      renderTrends(btn.dataset.mode!);
-    });
-  });
 
   // ---- 02 box plot by town ----
   function renderBox() {
@@ -270,15 +263,12 @@ try {
     renderLease();
     renderRecent();
   }
-  boot();
-
   // Pre-warm the DuckDB engine while the visitor reads the landing, so the first
   // click into an interactive page skips the cold start. Full warm (not just a byte
   // fetch): it downloads + instantiates, populating both the HTTP cache and the
   // browser's compiled-wasm code cache, which carries across the navigation. Dynamic-
   // imported to stay out of the landing bundle and deferred to idle so it never
   // competes with the landing's own render. Skipped under Save-Data.
-  warmEngineWhenIdle();
   function warmEngineWhenIdle() {
     if ((navigator as any).connection?.saveData) return;
     const idle: (cb: () => void) => void =
@@ -288,10 +278,40 @@ try {
     });
   }
 
-  window.addEventListener('resize', () => {
+  // ---- lifecycle: (re)build on each navigation, tear down on departure ----
+  function onResize() {
+    if (!active) return;
     trendChart?.resize();
     echarts.getInstanceByDom(q('chart-box'))?.resize();
     echarts.getInstanceByDom(q('chart-scatter'))?.resize();
     echarts.getInstanceByDom(q('chart-buckets'))?.resize();
-  });
+  }
+
+  function cleanup() {
+    if (!active) return; // only when leaving the landing (charts still in the live DOM)
+    active = false;
+    trendChart?.dispose();
+    trendChart = undefined;
+    echarts.getInstanceByDom(q('chart-box'))?.dispose();
+    echarts.getInstanceByDom(q('chart-scatter'))?.dispose();
+    echarts.getInstanceByDom(q('chart-buckets'))?.dispose();
+  }
+
+  async function init() {
+    if (!document.getElementById('chart-trends')) return; // not the landing
+    active = true;
+    document.querySelectorAll<HTMLButtonElement>('#trend-toggle .chip').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#trend-toggle .chip').forEach((b) => b.classList.remove('on'));
+        btn.classList.add('on');
+        renderTrends(btn.dataset.mode!);
+      });
+    });
+    await boot();
+    warmEngineWhenIdle();
+  }
+
+  window.addEventListener('resize', onResize);
+  document.addEventListener('astro:page-load', init);
+  document.addEventListener('astro:before-swap', cleanup);
 </script>

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -255,10 +255,11 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
   const pillClass = (d: number) => (d >= 1 ? 'up' : d <= -1 ? 'down' : 'flat');
   const arrow = (d: number) => (d >= 0 ? '▲' : '▼');
 
-  // ---- Leaflet map ----
-  const map = L.map('ins-map', { scrollWheelZoom: false }).setView([1.3521, 103.8198], 12);
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', { attribution: '© OpenStreetMap © CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
-  let layer = L.layerGroup().addTo(map);
+  // Instances persist across Astro client-side navigations; init() (re)creates them
+  // on each arrival and cleanup() tears them down. `active` gates the shared resize.
+  let map!: L.Map;
+  let layer!: L.LayerGroup;
+  let active = false;
 
   // ---- resolve a postal code → block metadata + populate dependent fields ----
   async function resolveBlock() {
@@ -326,6 +327,7 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
       `SELECT median(psf) psf, median(resale_price) price, median(floor_area_sqft) area
        FROM resale WHERE flat_type='${sql(flat)}' AND month >= strftime(current_date - INTERVAL 12 MONTH, '%Y-%m')`);
     const islandPsf = Number(island?.psf || 0), islandPrice = Number(island?.price || 0), islandArea = Number(island?.area || 0);
+    if (!active) return; // navigated away mid-query — don't touch the torn-down map/DOM
 
     // valuation — base median PSF over all comps, then adjust for the chosen storey band
     const baseMedPsf = med(comps.map((c) => c.psf));
@@ -414,30 +416,55 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
         .bindTooltip(`<b>Your flat</b> · ${titleCase(block.address)}<br/><b>${money(estimate)}</b> est · ${fpsf(medPsf)} psf`, { direction: 'top', offset: [0, -8], opacity: 1, className: 'hdb-tip' })
         .addTo(layer);
     }
-    if (pts.length) map.fitBounds(L.latLngBounds(pts).pad(0.15));
-    setTimeout(() => map.invalidateSize(), 50);
+    if (pts.length) map.fitBounds(L.latLngBounds(pts).pad(0.15), { animate: false }); // no rAF anim → no teardown race
+    setTimeout(() => { if (active) map.invalidateSize(); }, 50); // guard: may fire after teardown
   }
 
-  // ---- wiring ----
-  ($('f-postal') as HTMLInputElement).addEventListener('change', async () => { if (await resolveBlock()) compute(); });
-  $('f-flat').addEventListener('change', async () => { await onFlatChange(); compute(); });
-  ['f-storey', 'f-area', 'f-lease'].forEach((id) => $(id).addEventListener('change', compute));
-  $('get-insights').addEventListener('click', async () => {
-    const cur = parseInt(($('f-postal') as HTMLInputElement).value, 10);
-    // re-resolve only if the postal changed (avoid clobbering the user's edited fields)
-    if (cur !== resolvedPostal) { if (!(await resolveBlock())) return; }
-    await compute();
-    document.querySelector('.results')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
+  // ---- lifecycle: (re)build on each navigation, tear down on departure ----
+  function onResize() {
+    if (!active) return;
+    map.invalidateSize();
+  }
 
-  (async () => {
+  function cleanup() {
+    if (!active) return; // only when leaving this page — before-swap is global, avoid double-teardown
+    active = false;
+    map?.remove();
+  }
+
+  async function init() {
+    if (!document.getElementById('ins-map')) return; // not this page — astro:page-load is global
+    active = true;
+    block = { town: '', street: '', address: '', model: '', lc: 0 };
+    userLatLng = null;
+    resolvedPostal = 0;
+
+    map = L.map('ins-map', { scrollWheelZoom: false }).setView([1.3521, 103.8198], 12);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', { attribution: '© OpenStreetMap © CARTO', maxZoom: 19, subdomains: 'abcd' }).addTo(map);
+    layer = L.layerGroup().addTo(map);
+
+    // ---- wiring ----
+    ($('f-postal') as HTMLInputElement).addEventListener('change', async () => { if (await resolveBlock()) compute(); });
+    $('f-flat').addEventListener('change', async () => { await onFlatChange(); compute(); });
+    ['f-storey', 'f-area', 'f-lease'].forEach((id) => $(id).addEventListener('change', compute));
+    $('get-insights').addEventListener('click', async () => {
+      const cur = parseInt(($('f-postal') as HTMLInputElement).value, 10);
+      // re-resolve only if the postal changed (avoid clobbering the user's edited fields)
+      if (cur !== resolvedPostal) { if (!(await resolveBlock())) return; }
+      await compute();
+      document.querySelector('.results')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+
+    // ---- default valuation on load ----
     const [def] = await query<{ postal: number }>(`SELECT postal FROM resale WHERE postal IS NOT NULL GROUP BY postal ORDER BY count(*) DESC LIMIT 1`);
     ($('f-postal') as HTMLInputElement).value = String(def.postal);
     if (await resolveBlock()) {
       $('resolved').innerHTML = `Matched to <b>${titleCase(block.address)}</b>, ${titleCase(block.town)}`;
       await compute();
     }
-  })();
+  }
 
-  window.addEventListener('resize', () => map.invalidateSize());
+  window.addEventListener('resize', onResize);
+  document.addEventListener('astro:page-load', init);
+  document.addEventListener('astro:before-swap', cleanup);
 </script>

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -90,7 +90,10 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
   const dateOf = (idx: number) => new Date(2017 + Math.floor(idx / 12), idx % 12, 1).getTime();
   const monthLabel = (idx: number) => `${2017 + Math.floor(idx / 12)}-${String((idx % 12) + 1).padStart(2, '0')}`;
 
-  const chart = echarts.init($('chart-psf'));
+  // Instances persist across Astro client-side navigations; init() (re)creates the
+  // chart on each arrival and cleanup() disposes it. `active` gates the shared resize.
+  let chart!: ReturnType<typeof echarts.init>;
+  let active = false;
   let regType: 'ols' | 'loess' = 'ols';
   let fullMinIdx = 0, fullMaxIdx = 0; // full x-extent, for mapping zoom % → months
   let zoomTimer: ReturnType<typeof setTimeout>;
@@ -133,6 +136,7 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
         `SELECT month, median(psf) med, count(*) n FROM resale WHERE ${where} GROUP BY month ORDER BY month`,
       ),
     ]);
+    if (!active) return; // navigated away mid-query — don't touch the torn-down chart/DOM
 
     const title = `Price per sqft · ${titleCase(($('sel-town') as HTMLSelectElement).value)}`
       + (($('sel-street') as HTMLSelectElement).value !== '__all' ? ` · ${titleCase(($('sel-street') as HTMLSelectElement).value)}` : '');
@@ -251,15 +255,6 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     $('psf-foot').textContent = `Showing ${Math.min(8, pts.length)} of ${pts.length} months`;
   }
 
-  document.querySelectorAll<HTMLButtonElement>('#reg-toggle .chip').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('#reg-toggle .chip').forEach((b) => b.classList.remove('on'));
-      btn.classList.add('on');
-      regType = btn.dataset.reg as 'ols' | 'loess';
-      render();
-    });
-  });
-
   async function loadStreets() {
     const town = ($('sel-town') as HTMLSelectElement).value;
     const streets = await query<{ street_name: string }>(
@@ -269,16 +264,6 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
       `<option value="__all" selected>All streets</option>` +
       streets.map((s) => `<option value="${s.street_name}">${titleCase(s.street_name)}</option>`).join('');
   }
-
-  (async () => {
-    const towns = await query<{ town: string }>(`SELECT DISTINCT town FROM resale ORDER BY town`);
-    ($('sel-town') as HTMLSelectElement).innerHTML = towns.map((t) => `<option${t.town === 'ANG MO KIO' ? ' selected' : ''}>${t.town}</option>`).join('');
-    await loadStreets();
-    $('sel-town').addEventListener('change', async () => { await loadStreets(); render(); });
-    $('sel-street').addEventListener('change', render);
-    $('sel-storey').addEventListener('change', render);
-    render();
-  })();
 
   // semantic zoom: re-sample the scatter to the visible date window so zooming in reveals more detail
   async function resampleForZoom() {
@@ -300,7 +285,45 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     chart.setOption({ series: [{ data: toScatter(rows) }] });
     $('scatter-note').textContent = noteText(Number(cnt[0].n), ' in view');
   }
-  chart.on('datazoom', () => { clearTimeout(zoomTimer); zoomTimer = setTimeout(resampleForZoom, 350); });
+  // ---- lifecycle: (re)build on each navigation, tear down on departure ----
+  function onResize() {
+    if (!active) return;
+    chart.resize();
+  }
 
-  window.addEventListener('resize', () => chart.resize());
+  function cleanup() {
+    if (!active) return; // only when leaving this page — before-swap is global, avoid double-teardown
+    active = false;
+    clearTimeout(zoomTimer);
+    chart?.dispose();
+  }
+
+  async function init() {
+    if (!document.getElementById('chart-psf')) return; // not this page — astro:page-load is global
+    active = true;
+    regType = 'ols';
+    chart = echarts.init($('chart-psf'));
+    chart.on('datazoom', () => { clearTimeout(zoomTimer); zoomTimer = setTimeout(resampleForZoom, 350); });
+
+    document.querySelectorAll<HTMLButtonElement>('#reg-toggle .chip').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#reg-toggle .chip').forEach((b) => b.classList.remove('on'));
+        btn.classList.add('on');
+        regType = btn.dataset.reg as 'ols' | 'loess';
+        render();
+      });
+    });
+
+    const towns = await query<{ town: string }>(`SELECT DISTINCT town FROM resale ORDER BY town`);
+    ($('sel-town') as HTMLSelectElement).innerHTML = towns.map((t) => `<option${t.town === 'ANG MO KIO' ? ' selected' : ''}>${t.town}</option>`).join('');
+    await loadStreets();
+    $('sel-town').addEventListener('change', async () => { await loadStreets(); render(); });
+    $('sel-street').addEventListener('change', render);
+    $('sel-storey').addEventListener('change', render);
+    render();
+  }
+
+  window.addEventListener('resize', onResize);
+  document.addEventListener('astro:page-load', init);
+  document.addEventListener('astro:before-swap', cleanup);
 </script>

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -118,13 +118,13 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
   type Row = { lat: number; lng: number; price: number; address: string; month: string; storey: string; psf: number; lease: number; band?: string };
   let currentRows: Row[] = [];
 
-  // ---- Leaflet map (created once) ----
-  const map = L.map('map', { scrollWheelZoom: false, attributionControl: true }).setView([1.3521, 103.8198], 12);
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-    attribution: '© OpenStreetMap © CARTO', maxZoom: 19, subdomains: 'abcd',
-  }).addTo(map);
-  const cluster = (L as any).markerClusterGroup({ maxClusterRadius: 45, chunkedLoading: true });
-  map.addLayer(cluster);
+  // Instances persist across Astro client-side navigations; init() (re)creates them
+  // on each arrival and cleanup() tears them down. `active` gates the shared resize
+  // handler so it never touches a torn-down map/chart.
+  let map!: L.Map;
+  let cluster: any;
+  let highestChart!: ReturnType<typeof echarts.init>;
+  let active = false;
 
   function median(nums: number[]): number {
     if (!nums.length) return 0;
@@ -152,6 +152,7 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     const lo = med * (1 - thr), hi = med * (1 + thr);
     for (const r of rows) r.band = r.price < lo ? 'below' : r.price > hi ? 'above' : 'around';
     currentRows = rows;
+    if (!active) return; // navigated away mid-query — don't touch the torn-down map/DOM
 
     // markers
     cluster.clearLayers();
@@ -167,9 +168,9 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     }
     if (rows.length) {
       const b = L.latLngBounds(rows.map((r) => [r.lat, r.lng] as [number, number]));
-      map.fitBounds(b.pad(0.1));
+      map.fitBounds(b.pad(0.1), { animate: false }); // no rAF anim → no race if we navigate away mid-zoom
     }
-    setTimeout(() => map.invalidateSize(), 50);
+    setTimeout(() => { if (active) map.invalidateSize(); }, 50); // guard: may fire after teardown
 
     // summary
     const counts = { above: 0, around: 0, below: 0 } as Record<string, number>;
@@ -194,7 +195,6 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
   }
 
   // ---- highest sale per town ----
-  const highestChart = echarts.init($('chart-highest'));
   async function renderHighest() {
     const flat = ($('sel-flat') as HTMLSelectElement).value;
     const rows = await query<{ town: string; mx: number }>(
@@ -223,19 +223,45 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     });
   }
 
-  // ---- CSV download ----
-  $('dl-town').addEventListener('click', (e) => {
-    e.preventDefault();
-    const head = 'month,address,price,psf,remaining_lease_years,band\n';
-    const body = currentRows.map((r) => `${r.month},"${r.address}",${r.price},${r.psf.toFixed(0)},${r.lease},${r.band}`).join('\n');
-    const url = URL.createObjectURL(new Blob([head + body], { type: 'text/csv' }));
-    const a = document.createElement('a');
-    a.href = url; a.download = 'town-analysis.csv'; a.click();
-    URL.revokeObjectURL(url);
-  });
+  // ---- lifecycle: (re)build on each navigation, tear down on departure ----
+  function onResize() {
+    if (!active) return;
+    highestChart.resize();
+    map.invalidateSize();
+  }
 
-  // ---- boot: populate selects then render ----
-  (async () => {
+  function cleanup() {
+    if (!active) return; // only when leaving this page — before-swap is global, avoid double-teardown
+    active = false;
+    highestChart?.dispose();
+    map?.remove();
+  }
+
+  async function init() {
+    if (!document.getElementById('map')) return; // not this page — astro:page-load is global
+    active = true;
+    currentRows = [];
+
+    map = L.map('map', { scrollWheelZoom: false, attributionControl: true }).setView([1.3521, 103.8198], 12);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      attribution: '© OpenStreetMap © CARTO', maxZoom: 19, subdomains: 'abcd',
+    }).addTo(map);
+    cluster = (L as any).markerClusterGroup({ maxClusterRadius: 45, chunkedLoading: true });
+    map.addLayer(cluster);
+    highestChart = echarts.init($('chart-highest'));
+
+    // ---- CSV download ----
+    $('dl-town').addEventListener('click', (e) => {
+      e.preventDefault();
+      const head = 'month,address,price,psf,remaining_lease_years,band\n';
+      const body = currentRows.map((r) => `${r.month},"${r.address}",${r.price},${r.psf.toFixed(0)},${r.lease},${r.band}`).join('\n');
+      const url = URL.createObjectURL(new Blob([head + body], { type: 'text/csv' }));
+      const a = document.createElement('a');
+      a.href = url; a.download = 'town-analysis.csv'; a.click();
+      URL.revokeObjectURL(url);
+    });
+
+    // ---- populate selects then render ----
     const towns = await query<{ town: string }>(`SELECT DISTINCT town FROM resale ORDER BY town`);
     const flats = await query<{ flat_type: string }>(`SELECT DISTINCT flat_type FROM resale ORDER BY flat_type`);
     ($('sel-town') as HTMLSelectElement).innerHTML = towns.map((t) => `<option${t.town === 'ANG MO KIO' ? ' selected' : ''}>${t.town}</option>`).join('');
@@ -245,7 +271,9 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     $('sel-flat').addEventListener('change', () => { renderMap(); renderHighest(); });
     await renderMap();
     await renderHighest();
-  })();
+  }
 
-  window.addEventListener('resize', () => { highestChart.resize(); map.invalidateSize(); });
+  window.addEventListener('resize', onResize);
+  document.addEventListener('astro:page-load', init);
+  document.addEventListener('astro:before-swap', cleanup);
 </script>


### PR DESCRIPTION
## What

Make the DuckDB-WASM engine persist across page navigations, so it boots **once
per session** instead of once per page. Second-and-later interactive pages reuse
the warm engine (no re-download, no re-instantiate, no re-registered views).

Stacked on #11 (self-hosted engine) — review/merge that first.

## How (Phase 1–3 of the plan)

- **`<ClientRouter />`** in `Base.astro` — navigations become DOM swaps, not full
  reloads, so `window` and module singletons survive. Falls back to full navigation
  where View Transitions are unsupported (engine simply re-boots, i.e. old behavior).
- **`lib/db` singleton on `window`** — the connection is cached on `window.__duckdbConn`,
  so the warm engine survives navigation (and any accidental module re-eval).
- **Per-page lifecycle** — every page's script now (re)builds its UI on
  `astro:page-load` and tears it down on `astro:before-swap`, since bundled scripts
  only execute once under client-side routing. Handlers are `active`-gated (both
  events are global) so a page only touches its own DOM, and echarts/Leaflet
  instances are disposed on departure. Async renders bail if navigated away
  mid-query, and Leaflet `fitBounds` runs without animation to avoid a
  teardown-during-rAF race.

## Verification

Headless Chromium test driving real nav clicks (landing → town-analysis →
psf-trends → my-flat-insights → back to town-analysis), run repeatedly:

- **1 Web Worker created across all navigations** (proves the engine is reused, not
  re-booted per page).
- Every page renders after navigation (median, PSF stat, valuation all populate).
- **0 console/page errors** across runs.

## Not included

Hard-reload / cross-tab persistence (SharedWorker) and offline caching (service
worker) — deferred; see the plan. This covers the common case (soft navigation)
with the smallest, most idiomatic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
