### PR TITLE
fix(web): export prefetch() so the DuckDB engine actually pre-warms

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,67 @@
+name: Test web
+
+# End-to-end tests for the static Astro site (web/). Runs the real production
+# serving path — `bun run build` then `wrangler dev` (so src/worker.ts serves the
+# brotli-compressed DuckDB-WASM engine) — and drives it with Playwright/Chromium.
+#
+# The data shards are NOT committed (see web/.gitignore); like the deploy workflow,
+# we regenerate them here from data/df.parquet published to the `data` GitHub
+# Release, so the engine can boot end-to-end (register shards + create the view).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - "webapp/update/emit_web.py"
+      - ".github/workflows/test.yaml"
+  pull_request:
+    paths:
+      - "web/**"
+      - "webapp/update/emit_web.py"
+      - ".github/workflows/test.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Download latest parquet from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download data --pattern df.parquet --dir data --clobber
+
+      - name: Emit web data artifacts (year-sharded parquet + manifest)
+        run: uv run --with polars webapp/update/emit_web.py
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        working-directory: web
+        run: bunx playwright test
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,3 +12,8 @@ public/data/
 # Brotli-compressed DuckDB-WASM engine, staged from node_modules by
 # scripts/compress-duckdb.mjs on every build. Regenerated, so not committed.
 public/duckdb/
+
+# Playwright E2E output.
+test-results/
+playwright-report/
+playwright/.cache/

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -2,16 +2,17 @@ import { defineConfig } from 'astro/config';
 import { readFileSync } from 'node:fs';
 
 // Read straight from the installed package's manifest so the version can never
-// drift from what upload-duckdb-r2.mjs pushes to R2. Exposed to client code as
-// import.meta.env.PUBLIC_DUCKDB_VERSION, which src/lib/duckdbBundle.ts uses to
-// build the version-pinned /duckdb/<version>/ URLs.
+// drift from what scripts/compress-duckdb.mjs stages for the build. Exposed to
+// client code as import.meta.env.PUBLIC_DUCKDB_VERSION, which src/lib/duckdbBundle.ts
+// uses to build the version-pinned /duckdb/<version>/ URLs.
 const duckdbVersion = JSON.parse(
   readFileSync(new URL('./node_modules/@duckdb/duckdb-wasm/package.json', import.meta.url), 'utf8'),
 ).version;
 
-// `astro dev` doesn't run src/worker.ts, so /duckdb/* would 404 locally. Mirror the
-// Worker's jsDelivr fallback here so the engine loads in dev exactly as it does in
-// production before R2 is populated. Key format matches: "/duckdb/<version>/<file>".
+// `astro dev` doesn't run src/worker.ts, so /duckdb/* would 404 locally (the build
+// only emits the compressed `<file>.br`, not the `<file>.wasm` the client requests).
+// Mirror the Worker's jsDelivr fallback here so the engine loads in dev exactly as
+// its production fallback does. Key format matches: "/duckdb/<version>/<file>".
 const duckdbDevFallback = {
   name: 'duckdb-dev-fallback',
   configureServer(server) {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -13,6 +13,7 @@
         "leaflet.markercluster": "^1.5.3",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/leaflet": "^1.9.21",
         "@types/leaflet.markercluster": "^1.5.6",
         "playwright-core": "^1.61.1",
@@ -170,6 +171,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -635,6 +638,8 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
@@ -842,6 +847,8 @@
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "table-layout/array-back": ["array-back@6.2.3", "", {}, "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "astro dev",
     "build": "node scripts/compress-duckdb.mjs && astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "playwright test",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.29.0",
@@ -17,6 +19,7 @@
     "leaflet.markercluster": "^1.5.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/leaflet": "^1.9.21",
     "@types/leaflet.markercluster": "^1.5.6",
     "playwright-core": "^1.61.1",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E tests run against the REAL production serving path: `bun run build`
+// (compresses the DuckDB engine + emits ./dist) followed by `wrangler dev`, so
+// src/worker.ts runs and /duckdb/*.wasm is served brotli'd with Content-Encoding: br
+// — exactly as in production. `astro preview` would 404 on the engine (it only
+// serves the compressed `.br` asset, not the `.wasm` the client requests).
+const PORT = 8788;
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `bun run build && bunx wrangler dev --port ${PORT} --ip 127.0.0.1`,
+    url: `http://localhost:${PORT}`,
+    timeout: 240_000,
+    reuseExistingServer: !process.env.CI,
+    // Keep wrangler non-interactive in CI (no telemetry / update prompts).
+    env: { WRANGLER_SEND_METRICS: 'false', CI: process.env.CI ?? '' },
+  },
+});

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -26,8 +26,9 @@ export function getManifest(): Promise<Manifest> {
 }
 
 async function boot(): Promise<duckdb.AsyncDuckDBConnection> {
-  // Self-hosted engine served same-origin from R2 via src/worker.ts (see
-  // src/lib/duckdbBundle.ts). selectBundle picks eh vs. mvp from browser features;
+  // Self-hosted engine served same-origin by src/worker.ts, which re-serves the
+  // brotli-compressed .wasm with Content-Encoding: br (see src/lib/duckdbBundle.ts).
+  // selectBundle picks eh vs. mvp from browser features;
   // both are absolute URLs so the blob worker's importScripts resolves them.
   const dir = new URL(duckdbBase(), window.location.href).href;
   const bundle = await duckdb.selectBundle({
@@ -56,8 +57,28 @@ async function boot(): Promise<duckdb.AsyncDuckDBConnection> {
 }
 
 function getConn(): Promise<duckdb.AsyncDuckDBConnection> {
-  if (!connPromise) connPromise = boot();
+  if (!connPromise) {
+    const p = boot();
+    // Don't cache a failed boot for the rest of the session: if a transient error
+    // (wasm/worker/manifest/parquet fetch) rejects it, drop the cached promise so
+    // the next getConn() retries instead of re-throwing the same rejection forever.
+    p.catch(() => {
+      if (connPromise === p) connPromise = null;
+    });
+    connPromise = p;
+  }
   return connPromise;
+}
+
+/**
+ * Eagerly boot the engine (download + instantiate + register shards + create the
+ * `resale` view) so the first query() resolves instantly. Pages that render a
+ * default view on load call this to overlap the WASM download with DOM wiring.
+ * Idempotent — reuses the cached connection; boot errors are swallowed here and
+ * surface on the actual query() instead.
+ */
+export function prefetch(): void {
+  void getConn().catch(() => {});
 }
 
 /** Run SQL against the `resale` view and return plain JS row objects. */

--- a/web/src/lib/duckdbBundle.ts
+++ b/web/src/lib/duckdbBundle.ts
@@ -1,11 +1,13 @@
 // Single source of truth for the self-hosted DuckDB-WASM bundle URLs.
 //
-// The engine (~34 MiB of .wasm plus its worker) is copied out of node_modules
-// into public/duckdb/<version>/ at build time by scripts/copy-duckdb.mjs and
-// served from our own origin — so Cloudflare caches it immutably and pages can
-// prefetch it, instead of streaming it cross-origin from jsDelivr. The version is
-// injected from the installed @duckdb/duckdb-wasm package by astro.config.mjs
-// (PUBLIC_DUCKDB_VERSION), so this path can never drift from what was copied.
+// The engine (~34 MiB of .wasm plus its worker) is staged into
+// public/duckdb/<version>/ at build time by scripts/compress-duckdb.mjs, which
+// brotli-compresses the .wasm to ~4.5 MiB (under Cloudflare's 25 MiB static-asset
+// cap); src/worker.ts re-serves it same-origin with Content-Encoding: br. Serving
+// from our own origin lets Cloudflare cache it immutably and pages prefetch it,
+// instead of streaming it cross-origin from jsDelivr. The version is injected from
+// the installed @duckdb/duckdb-wasm package by astro.config.mjs
+// (PUBLIC_DUCKDB_VERSION), so this path can never drift from what was staged.
 const VERSION = import.meta.env.PUBLIC_DUCKDB_VERSION;
 
 /** Root-relative dir holding this version's bundle files, e.g. `/duckdb/1.29.0/`. */

--- a/web/tests/prefetch.spec.ts
+++ b/web/tests/prefetch.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+// Regression guard for the landing-page DuckDB engine pre-warm.
+//
+// The landing (/) never queries DuckDB itself — it renders from overview.json. Its
+// ONLY trigger for downloading + booting the WASM engine is the idle-time
+// `prefetch()` call in index.astro. When `prefetch` was missing from src/lib/db.ts,
+// that call threw a TypeError that `.catch(() => {})` swallowed, so the engine never
+// warmed and the first click into an interactive page paid the full cold start.
+//
+// Crucially, unlike the interactive pages, the landing has NO `<link rel="prefetch">`
+// for the wasm — so a network request for duckdb-eh.wasm proves the JS prefetch()
+// path ran, not merely a declarative byte fetch. With the bug, no DuckDB request
+// fires on the landing at all.
+test('landing pre-warms the DuckDB engine on load, with no interaction', async ({ page }) => {
+  const wasmReq = page.waitForRequest(/\/duckdb\/.*\/duckdb-eh\.wasm$/, { timeout: 45_000 });
+  const manifestReq = page.waitForRequest(/\/data\/manifest\.json$/, { timeout: 45_000 });
+  const parquetReq = page.waitForRequest(/\/data\/resale-.*\.parquet$/, { timeout: 45_000 });
+
+  await page.goto('/');
+  // Deliberately NO clicks or typing — the warm must happen on its own.
+
+  // 1. The engine wasm is requested (prefetch -> getConn -> boot -> instantiate).
+  const req = await wasmReq;
+  const res = await req.response();
+  expect(res, 'engine wasm should get a response').not.toBeNull();
+  // 200 (not a 3xx) confirms it was served by src/worker.ts from the brotli asset,
+  // not redirected to the jsDelivr fallback (which would mean the compressed asset
+  // was missing). Content-Type is what WebAssembly.instantiateStreaming requires.
+  expect(res!.status()).toBe(200);
+  expect(res!.url()).toContain('/duckdb/');
+  expect(res!.headers()['content-type']).toBe('application/wasm');
+
+  // 2. manifest.json is fetched only from inside boot() (after a successful
+  //    instantiate), so this proves prefetch drove a real boot — not just a byte
+  //    fetch — and that the brotli-served wasm actually compiled.
+  await manifestReq;
+
+  // 3. read_parquet(...) in the CREATE VIEW pulls shard data: full end-to-end boot.
+  await parquetReq;
+});


### PR DESCRIPTION
## Problem

Four pages call `m.prefetch()` on load to warm the DuckDB-WASM engine while the visitor is reading, so the first query is instant:

```js
import('../lib/db').then((m) => m.prefetch()).catch(() => {});
```

But `src/lib/db.ts` only exported `getManifest` and `query` — **there was no `prefetch`**. So `m.prefetch` was `undefined`, the call threw a `TypeError`, and the `.catch(() => {})` swallowed it silently.

Impact is worst on the **landing page**: it never queries DuckDB itself (it renders from `overview.json`) and has no `<link rel="prefetch">` for the wasm, so that JS call was its *only* warm trigger. With it broken, the engine never warmed and the first click into an interactive page paid the full cold start.

## Changes

- **Add & export `prefetch()`** — boots the engine via `getConn()` (download + instantiate + register shards + create the `resale` view).
- **Don't cache a failed boot for the whole session** — if a transient fetch (wasm/worker/manifest/parquet) rejects, drop the cached promise so the next `query()` retries instead of re-throwing the same rejection forever.
- **Fix stale comments** in `db.ts`, `duckdbBundle.ts`, and `astro.config.mjs` that referenced an abandoned R2 approach and a non-existent `copy-duckdb.mjs`/`upload-duckdb-r2.mjs` (the real path is `compress-duckdb.mjs` → brotli → `worker.ts`).

## Test

New Playwright E2E (`web/tests/prefetch.spec.ts`) runs against the **real production serving path** — `bun run build` then `wrangler dev`, so `src/worker.ts` serves the brotli-compressed engine with `Content-Encoding: br`. It loads `/` with **no interaction** and asserts the engine warms end-to-end:

1. `duckdb-eh.wasm` is requested and served `200` as `application/wasm` (not the jsDelivr fallback).
2. `manifest.json` is fetched (only happens *inside* `boot()`, after a successful instantiate → proves the brotli wasm actually compiled).
3. A `resale-*.parquet` shard is fetched (the `CREATE VIEW read_parquet(...)` ran).

Verified it **fails** when `prefetch` is removed (times out — engine never warms), and passes with the fix. Added `.github/workflows/test.yaml` to run it in CI (regenerates data from the `data` release like the deploy workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)