### PR TITLE
fix(web): sample PSF scatter after filtering, not before

### DIFF
--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -101,9 +101,16 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
       value: [dateOf(idxOf(r.month)), Number(r.psf)],
       address: r.address, month: r.month, storey: r.storey, price: Number(r.price), psf: Number(r.psf), lease: Number(r.lease),
     }));
+  // `USING SAMPLE n ROWS` binds to the table scan and runs BEFORE the WHERE filter,
+  // so sampling `resale` directly would draw n rows from the whole table and only
+  // then filter — leaving a handful of matches for a narrow filter (e.g. one street +
+  // storey band). Wrap the filtered query in a subquery so the sample applies to the
+  // already-filtered rows (returns all of them when the set is under the cap).
   const sampleSql = (where: string) =>
-    `SELECT month, psf, address, storey_range storey, resale_price price, remaining_lease_years lease
-     FROM resale WHERE ${where} USING SAMPLE ${SCATTER_CAP} ROWS`;
+    `SELECT * FROM (
+       SELECT month, psf, address, storey_range storey, resale_price price, remaining_lease_years lease
+       FROM resale WHERE ${where}
+     ) USING SAMPLE ${SCATTER_CAP} ROWS`;
   const noteText = (total: number, suffix = '') =>
     (total > SCATTER_CAP ? `random sample of ${SCATTER_CAP.toLocaleString()} of ${total.toLocaleString()}` : `all ${total.toLocaleString()}`) + ` transactions${suffix}`;
   if (import.meta.env.DEV) {


### PR DESCRIPTION
## Problem

On the PSF Trends page, the scatter plot showed only a handful of dots (all clustered in early years) even when the chart correctly reported hundreds of transactions and drew a full trend line across the whole range.

## Root cause

The scatter query sampled the table *before* filtering:

```sql
SELECT ... FROM resale WHERE <filter> USING SAMPLE 6000 ROWS
```

In DuckDB, `USING SAMPLE` binds to the table scan and runs **before** the `WHERE` clause. So it drew ~6000 random rows from the full ~236k-row `resale` table and *then* applied the filter, leaving `6000 × 443/236k ≈ 10` surviving rows for a narrow filter.

The trend line and transaction count were always correct — they come from a separate `GROUP BY month` aggregation that filters normally. Only the scatter was starved, producing the mismatch.

## Fix

Wrap the filtered query in a subquery so the filter runs first and the sample applies to the already-filtered rows:

```sql
SELECT * FROM (
  SELECT ... FROM resale WHERE <filter>
) USING SAMPLE 6000 ROWS
```

## Verification

- Wide filters still cap correctly (all-Clementi returns 3,820, under the 6000 cap).
- `resampleForZoom` reuses the same `sampleSql`, so the zoom path is fixed too.
- Only occurrence of `USING SAMPLE` in `web/src` — no other pages affected.
- `bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)