### PR TITLE
perf(web): cut town-analysis cold load (~5.3s → shell-fast)

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -18,6 +18,14 @@ const duckdbDevFallback = {
   configureServer(server) {
     server.middlewares.use('/duckdb', (req, res) => {
       const key = (req.url ?? '').replace(/^\//, '').split('?')[0]; // "<version>/<file>"
+      // Extension requests (…/ext/<core>/<platform>/<name>) go upstream to the DuckDB
+      // extension repo, matching src/worker.ts's fallback.
+      const extIdx = key.indexOf('/ext/');
+      if (extIdx !== -1) {
+        res.statusCode = 302;
+        res.setHeader('Location', `https://extensions.duckdb.org/${key.slice(extIdx + '/ext/'.length)}`);
+        return res.end();
+      }
       const slash = key.indexOf('/');
       if (slash === -1) {
         res.statusCode = 404;

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -29,7 +29,11 @@
 /data/manifest.json
   Cache-Control: public, max-age=0, must-revalidate
 
-# The landing's precomputed aggregate. Stable name, changes daily — cache like the
-# shards so repeat visits paint from disk instead of a revalidation round-trip.
+# Precomputed page snapshots (landing + town-analysis default view). Stable names,
+# change daily — cache like the data file so repeat visits paint from disk instead of
+# a revalidation round-trip.
 /data/overview.json
+  Cache-Control: public, max-age=3600, must-revalidate
+
+/data/town-analysis.json
   Cache-Control: public, max-age=3600, must-revalidate

--- a/web/public/_headers
+++ b/web/public/_headers
@@ -19,13 +19,9 @@
 /duckdb/*
   Cache-Control: public, max-age=31536000, immutable
 
-# Data shard filenames are stable but their contents change on each daily ETL run,
-# so revalidate rather than pin. DuckDB fetches these via HTTP range requests.
-# Trailing splat (not `*.parquet`): Cloudflare's matcher allows one greedy splat
-# and doesn't reliably match text after it. Shards are all named resale-*.parquet,
-# so this catches them without overlapping the manifest.json rule below (overlapping
-# rules would comma-join their Cache-Control values).
-/data/resale-*
+# The data file's name is stable but its contents change on each daily ETL run, so
+# revalidate rather than pin. DuckDB fetches it via HTTP range requests.
+/data/resale.parquet
   Cache-Control: public, max-age=3600, must-revalidate
 
 # The manifest gates which shards load and carries lastUpdated — always revalidate

--- a/web/scripts/compress-duckdb.mjs
+++ b/web/scripts/compress-duckdb.mjs
@@ -5,11 +5,21 @@
 // ~8x smaller download. src/worker.ts serves those back with Content-Encoding: br.
 // The small worker .js files ship as-is (Cloudflare compresses them at the edge).
 //
+// We also stage the `parquet` extension so read_parquet() doesn't fetch it cross-origin
+// from extensions.duckdb.org at runtime (see db.ts SET custom_extension_repository).
+//
 // Runs as part of `bun run build` (see package.json). The output is gitignored and
 // regenerated each build, so it always matches the pinned @duckdb/duckdb-wasm version.
 import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from 'node:fs';
 import { brotliCompressSync, constants } from 'node:zlib';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+
+// Underlying DuckDB core version for this @duckdb/duckdb-wasm release. It appears in
+// the extension URL (extensions.duckdb.org/<core>/<platform>/…) and MUST match the
+// version DuckDB requests at runtime. Bump when upgrading duckdb-wasm; if it's wrong
+// the extension download below fails loudly, and at runtime the Worker falls back to
+// extensions.duckdb.org so queries keep working regardless.
+const DUCKDB_CORE = 'v1.1.1';
 
 const DIST = 'node_modules/@duckdb/duckdb-wasm/dist';
 const version = JSON.parse(readFileSync('node_modules/@duckdb/duckdb-wasm/package.json', 'utf8')).version;
@@ -18,15 +28,18 @@ mkdirSync(outDir, { recursive: true });
 
 // Max quality (q11): compression is a one-time build cost, but the result is cached
 // immutably in the browser, so the smaller download pays off on every first visit.
-const wasm = ['duckdb-eh.wasm', 'duckdb-mvp.wasm'];
-for (const f of wasm) {
-  const raw = readFileSync(join(DIST, f));
-  const br = brotliCompressSync(raw, {
+const brotli = (raw) =>
+  brotliCompressSync(raw, {
     params: {
       [constants.BROTLI_PARAM_QUALITY]: 11,
       [constants.BROTLI_PARAM_SIZE_HINT]: raw.length,
     },
   });
+
+const wasm = ['duckdb-eh.wasm', 'duckdb-mvp.wasm'];
+for (const f of wasm) {
+  const raw = readFileSync(join(DIST, f));
+  const br = brotli(raw);
   writeFileSync(join(outDir, `${f}.br`), br);
   console.log(`brotli ${f}: ${(raw.length / 1048576).toFixed(1)} → ${(br.length / 1048576).toFixed(1)} MiB`);
 }
@@ -34,4 +47,27 @@ for (const f of wasm) {
 const workers = ['duckdb-browser-eh.worker.js', 'duckdb-browser-mvp.worker.js'];
 for (const f of workers) copyFileSync(join(DIST, f), join(outDir, f));
 
-console.log(`DuckDB-WASM ${version} staged → ${outDir}`);
+// Stage the parquet extension for both bundles at the path DuckDB will request under
+// our custom repo: <repo>/<core>/<platform>/parquet.duckdb_extension.wasm. The Worker
+// serves the `.br` back with Content-Encoding: br, exactly like the engine .wasm.
+// Non-fatal: a build without network still ships; the runtime just falls back to the
+// upstream repo (via the Worker) for the extension.
+for (const platform of ['wasm_eh', 'wasm_mvp']) {
+  const name = 'parquet.duckdb_extension.wasm';
+  const url = `https://extensions.duckdb.org/${DUCKDB_CORE}/${platform}/${name}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const raw = Buffer.from(await res.arrayBuffer());
+    const dest = join(outDir, 'ext', DUCKDB_CORE, platform, `${name}.br`);
+    mkdirSync(dirname(dest), { recursive: true });
+    const br = brotli(raw);
+    writeFileSync(dest, br);
+    console.log(`brotli ${platform}/${name}: ${(raw.length / 1024).toFixed(0)} → ${(br.length / 1024).toFixed(0)} KiB`);
+  } catch (err) {
+    console.warn(`WARNING: could not stage ${platform} parquet extension (${err.message}); ` +
+      'runtime will fall back to extensions.duckdb.org.');
+  }
+}
+
+console.log(`DuckDB-WASM ${version} (core ${DUCKDB_CORE}) staged → ${outDir}`);

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -2,7 +2,7 @@
 // Lazily boots the WASM engine, registers resale.parquet from manifest.json, and
 // exposes a typed query() helper. Runs entirely in the browser — no backend.
 import * as duckdb from '@duckdb/duckdb-wasm';
-import { duckdbBase } from './duckdbBundle';
+import { duckdbBase, duckdbExtRepo } from './duckdbBundle';
 
 export interface Manifest {
   lastUpdated: string | null;
@@ -48,6 +48,10 @@ async function boot(): Promise<duckdb.AsyncDuckDBConnection> {
   await db.registerFileURL(manifest.file, base + manifest.file, duckdb.DuckDBDataProtocol.HTTP, false);
 
   const conn = await db.connect();
+  // Autoload the parquet extension from our own origin instead of extensions.duckdb.org
+  // (see duckdbExtRepo / src/worker.ts). Must be set before the first read_parquet.
+  const extRepo = new URL(duckdbExtRepo(), window.location.href).href;
+  await conn.query(`SET custom_extension_repository='${extRepo}'`);
   // Query the file as `resale`. DuckDB reads it lazily over HTTP range requests.
   await conn.query(`CREATE VIEW resale AS SELECT * FROM read_parquet('${manifest.file}')`);
   return conn;

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,5 +1,5 @@
-// Client-side data layer: DuckDB-WASM over the year-sharded Parquet in /data.
-// Lazily boots the WASM engine, registers every shard from manifest.json, and
+// Client-side data layer: DuckDB-WASM over the single Parquet file in /data.
+// Lazily boots the WASM engine, registers resale.parquet from manifest.json, and
 // exposes a typed query() helper. Runs entirely in the browser — no backend.
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { duckdbBase } from './duckdbBundle';
@@ -7,8 +7,8 @@ import { duckdbBase } from './duckdbBundle';
 export interface Manifest {
   lastUpdated: string | null;
   rows: number;
-  years: string[];
-  shards: { year: string; file: string; rows: number; bytes: number }[];
+  file: string;
+  bytes: number;
   columns: string[];
 }
 
@@ -45,14 +45,11 @@ async function boot(): Promise<duckdb.AsyncDuckDBConnection> {
 
   const manifest = await getManifest();
   const base = new URL(`${import.meta.env.BASE_URL}data/`, window.location.href).href;
-  for (const s of manifest.shards) {
-    await db.registerFileURL(s.file, base + s.file, duckdb.DuckDBDataProtocol.HTTP, false);
-  }
+  await db.registerFileURL(manifest.file, base + manifest.file, duckdb.DuckDBDataProtocol.HTTP, false);
 
   const conn = await db.connect();
-  // A single view spanning every shard — query `resale` like one table.
-  const list = manifest.shards.map((s) => `'${s.file}'`).join(', ');
-  await conn.query(`CREATE VIEW resale AS SELECT * FROM read_parquet([${list}])`);
+  // Query the file as `resale`. DuckDB reads it lazily over HTTP range requests.
+  await conn.query(`CREATE VIEW resale AS SELECT * FROM read_parquet('${manifest.file}')`);
   return conn;
 }
 

--- a/web/src/lib/duckdbBundle.ts
+++ b/web/src/lib/duckdbBundle.ts
@@ -4,24 +4,15 @@
 // public/duckdb/<version>/ at build time by scripts/compress-duckdb.mjs, which
 // brotli-compresses the .wasm to ~4.5 MiB (under Cloudflare's 25 MiB static-asset
 // cap); src/worker.ts re-serves it same-origin with Content-Encoding: br. Serving
-// from our own origin lets Cloudflare cache it immutably and pages prefetch it,
-// instead of streaming it cross-origin from jsDelivr. The version is injected from
-// the installed @duckdb/duckdb-wasm package by astro.config.mjs
-// (PUBLIC_DUCKDB_VERSION), so this path can never drift from what was staged.
+// from our own origin lets Cloudflare cache it immutably, instead of streaming it
+// cross-origin from jsDelivr. The version is injected from the installed
+// @duckdb/duckdb-wasm package by astro.config.mjs (PUBLIC_DUCKDB_VERSION), so this
+// path can never drift from what was staged.
 const VERSION = import.meta.env.PUBLIC_DUCKDB_VERSION;
 
 /** Root-relative dir holding this version's bundle files, e.g. `/duckdb/1.29.0/`. */
 export function duckdbBase(base: string = import.meta.env.BASE_URL): string {
   return `${base}duckdb/${VERSION}/`;
-}
-
-/**
- * URL of the exception-handling wasm module — the bundle selectBundle() picks on
- * every browser we support. Pages `<link rel="prefetch">` this to warm the HTTP
- * cache before the first query spins up the engine.
- */
-export function ehWasmUrl(base?: string): string {
-  return `${duckdbBase(base)}duckdb-eh.wasm`;
 }
 
 /**

--- a/web/src/lib/duckdbBundle.ts
+++ b/web/src/lib/duckdbBundle.ts
@@ -23,3 +23,14 @@ export function duckdbBase(base: string = import.meta.env.BASE_URL): string {
 export function ehWasmUrl(base?: string): string {
   return `${duckdbBase(base)}duckdb-eh.wasm`;
 }
+
+/**
+ * Same-origin extension repository. DuckDB appends `/<core>/<platform>/<name>.wasm`,
+ * which src/worker.ts serves from the brotli-staged copy (scripts/compress-duckdb.mjs),
+ * so read_parquet() doesn't fetch the parquet extension cross-origin from
+ * extensions.duckdb.org. If a file is missing the Worker falls back to that upstream.
+ */
+export function duckdbExtRepo(base?: string): string {
+  // No trailing slash — DuckDB joins the version/platform path itself.
+  return `${duckdbBase(base)}ext`.replace(/\/$/, '');
+}

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -1,12 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
-import { ehWasmUrl } from '../lib/duckdbBundle';
 ---
 
 <Base active="My Flat Insights" title="My Flat Insights — HDB Kaki">
-  <!-- This page auto-computes a default valuation on load; warm the same-origin
-       DuckDB engine in parallel with parse so it isn't blocked on a cold fetch. -->
-  <link slot="head" rel="prefetch" href={ehWasmUrl()} as="fetch" />
+  <!-- This page auto-computes a default valuation on load, so the script eagerly warms
+       the same-origin DuckDB engine. That warm downloads + instantiates the wasm, so we
+       deliberately do NOT also <link rel="prefetch"> it — that only double-downloaded
+       the ~4.7 MB wasm (prefetch cache isn't reused by the worker's instantiate fetch). -->
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> New · Personalised</span>

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -1,12 +1,12 @@
 ---
 import Base from '../layouts/Base.astro';
-import { ehWasmUrl } from '../lib/duckdbBundle';
 ---
 
 <Base active="PSF Trends" title="PSF Trends — HDB Kaki">
-  <!-- This page auto-runs a query on load; warm the same-origin DuckDB engine in
-       parallel with parse so the first query isn't blocked on a cold ~34 MiB fetch. -->
-  <link slot="head" rel="prefetch" href={ehWasmUrl()} as="fetch" />
+  <!-- This page auto-runs a query on load, so the script eagerly warms the same-origin
+       DuckDB engine. That warm downloads + instantiates the wasm, so we deliberately do
+       NOT also <link rel="prefetch"> it — that only double-downloaded the ~4.7 MB wasm
+       (prefetch cache isn't reused by the worker's instantiate fetch). -->
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> Price per Square Foot</span>

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -1,12 +1,11 @@
 ---
 import Base from '../layouts/Base.astro';
-import { ehWasmUrl } from '../lib/duckdbBundle';
 ---
 
 <Base active="Town Analysis" title="Town Analysis — HDB Kaki">
-  <!-- This page auto-runs a query on load; warm the same-origin DuckDB engine in
-       parallel with parse so the first query isn't blocked on a cold ~34 MiB fetch. -->
-  <link slot="head" rel="prefetch" href={ehWasmUrl()} as="fetch" />
+  <!-- The default view paints from a precomputed JSON snapshot (town-analysis.json),
+       so DuckDB is NOT on the load path — the engine is warmed on idle and only booted
+       when the visitor changes a filter. -->
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> Explore by Town</span>
@@ -96,27 +95,29 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
   import L from 'leaflet';
   import 'leaflet.markercluster';
   import echarts from '../lib/echarts';
-  // DuckDB-WASM is heavy; load it lazily so the page shell is interactive first and
-  // the engine only downloads when a query actually runs.
+  // DuckDB-WASM is heavy and NOT needed for first paint: the default view renders from
+  // a precomputed snapshot (town-analysis.json). The engine is imported lazily and only
+  // booted when the visitor changes a filter (warmed on idle so that first change is
+  // snappy). The query() wrapper primes the same lazy import the warm path reuses.
   let _db: Promise<typeof import('../lib/db')> | null = null;
   const query = async <T = any>(sql: string): Promise<T[]> => {
     if (!_db) _db = import('../lib/db');
     return (await _db).query<T>(sql);
   };
-  // This page renders a default view on load, so start warming the engine now —
-  // overlapping the WASM download with DOM wiring instead of waiting for the first
-  // query. (Idempotent: primes the same _db the query wrapper reuses.)
-  _db = import('../lib/db');
-  _db.then((m) => m.prefetch()).catch(() => {});
   import { baseOption, palette, axisLabel, splitLine, axisLine, ink3, ink } from '../lib/echartsTheme';
   import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
 
+  const DEFAULT_TOWN = 'ANG MO KIO';
+  const DEFAULT_FLAT = '4 ROOM';
   const $ = (id: string) => document.getElementById(id)!;
   const BAND_COLOR: Record<string, string> = { above: '#fe012b', around: '#d98a2b', below: '#1f7a4d' };
   const sql = (s: string) => s.replace(/'/g, "''");
 
   type Row = { lat: number; lng: number; price: number; address: string; month: string; storey: string; psf: number; lease: number; band?: string };
+  type Hi = { town: string; mx: number };
   let currentRows: Row[] = [];
+  let currentTown = DEFAULT_TOWN;
+  let currentFlat = DEFAULT_FLAT;
 
   // ---- Leaflet map (created once) ----
   const map = L.map('map', { scrollWheelZoom: false, attributionControl: true }).setView([1.3521, 103.8198], 12);
@@ -133,25 +134,17 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
   }
 
-  async function renderMap() {
-    const town = (($('sel-town') as HTMLSelectElement).value) || 'ANG MO KIO';
-    const flat = ($('sel-flat') as HTMLSelectElement).value;
+  // Paint the map + summary + table from already-fetched rows. Pure client-side, so
+  // changing only the threshold re-bands the same rows without touching DuckDB.
+  function paintMap(rows: Row[], town: string, flat: string) {
+    currentRows = rows;
+    currentTown = town;
+    currentFlat = flat;
     const thr = parseFloat(($('sel-thr') as HTMLSelectElement).value);
-
-    const rows = await query<Row>(
-      `SELECT latitude lat, longitude lng, resale_price price, address, month,
-              storey_range storey, psf, remaining_lease_years lease
-       FROM resale
-       WHERE town='${sql(town)}' AND flat_type='${sql(flat)}'
-         AND month >= strftime(current_date - INTERVAL 24 MONTH, '%Y-%m')
-         AND latitude IS NOT NULL
-       ORDER BY month DESC, resale_price DESC`,
-    ).then((rs) => rs.map((r) => ({ ...r, price: Number(r.price), psf: Number(r.psf), lat: Number(r.lat), lng: Number(r.lng), lease: Number(r.lease) })));
 
     const med = median(rows.map((r) => r.price));
     const lo = med * (1 - thr), hi = med * (1 + thr);
     for (const r of rows) r.band = r.price < lo ? 'below' : r.price > hi ? 'above' : 'around';
-    currentRows = rows;
 
     // markers
     cluster.clearLayers();
@@ -193,15 +186,28 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     $('town-foot').textContent = `Showing ${Math.min(12, rows.length)} of ${rows.length.toLocaleString()} sales in view`;
   }
 
+  // Fetch rows for the current town/flat from DuckDB, then paint. Mirrors the SQL the
+  // default snapshot was precomputed from (see webapp/update/emit_web.py).
+  async function loadMap() {
+    const town = (($('sel-town') as HTMLSelectElement).value) || DEFAULT_TOWN;
+    const flat = ($('sel-flat') as HTMLSelectElement).value;
+    const rows = await query<Row>(
+      `SELECT latitude lat, longitude lng, resale_price price, address, month,
+              storey_range storey, psf, remaining_lease_years lease
+       FROM resale
+       WHERE town='${sql(town)}' AND flat_type='${sql(flat)}'
+         AND month >= strftime(current_date - INTERVAL 24 MONTH, '%Y-%m')
+         AND latitude IS NOT NULL
+       ORDER BY month DESC, resale_price DESC`,
+    ).then((rs) => rs.map((r) => ({ ...r, price: Number(r.price), psf: Number(r.psf), lat: Number(r.lat), lng: Number(r.lng), lease: Number(r.lease) })));
+    paintMap(rows, town, flat);
+  }
+
   // ---- highest sale per town ----
   const highestChart = echarts.init($('chart-highest'));
-  async function renderHighest() {
-    const flat = ($('sel-flat') as HTMLSelectElement).value;
-    const rows = await query<{ town: string; mx: number }>(
-      `SELECT town, max(resale_price) mx FROM resale WHERE flat_type='${sql(flat)}' GROUP BY town ORDER BY mx DESC LIMIT 15`,
-    ).then((rs) => rs.map((r) => ({ town: r.town, mx: Number(r.mx) })));
-    const med = median(rows.map((r) => r.mx));
-    rows.reverse(); // ECharts horizontal bar draws bottom-up
+  function paintHighest(input: Hi[]) {
+    const med = median(input.map((r) => r.mx));
+    const rows = [...input].reverse(); // ECharts horizontal bar draws bottom-up
     highestChart.setOption({
       ...baseOption(),
       grid: { left: 120, right: 70, top: 12, bottom: 30, containLabel: false },
@@ -222,6 +228,13 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
       }],
     });
   }
+  async function loadHighest() {
+    const flat = ($('sel-flat') as HTMLSelectElement).value;
+    const rows = await query<Hi>(
+      `SELECT town, max(resale_price) mx FROM resale WHERE flat_type='${sql(flat)}' GROUP BY town ORDER BY mx DESC LIMIT 15`,
+    ).then((rs) => rs.map((r) => ({ town: r.town, mx: Number(r.mx) })));
+    paintHighest(rows);
+  }
 
   // ---- CSV download ----
   $('dl-town').addEventListener('click', (e) => {
@@ -234,18 +247,40 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     URL.revokeObjectURL(url);
   });
 
-  // ---- boot: populate selects then render ----
+  // ---- boot: paint the default view from the precomputed snapshot, then wire filters ----
+  type Snapshot = { default: { town: string; flat: string }; towns: string[]; flatTypes: string[]; rows: Row[]; highest: Hi[] };
   (async () => {
-    const towns = await query<{ town: string }>(`SELECT DISTINCT town FROM resale ORDER BY town`);
-    const flats = await query<{ flat_type: string }>(`SELECT DISTINCT flat_type FROM resale ORDER BY flat_type`);
-    ($('sel-town') as HTMLSelectElement).innerHTML = towns.map((t) => `<option${t.town === 'ANG MO KIO' ? ' selected' : ''}>${t.town}</option>`).join('');
-    ($('sel-flat') as HTMLSelectElement).innerHTML = flats.map((f) => `<option${f.flat_type === '4 ROOM' ? ' selected' : ''}>${f.flat_type}</option>`).join('');
-    $('sel-town').addEventListener('change', renderMap);
-    $('sel-thr').addEventListener('change', renderMap);
-    $('sel-flat').addEventListener('change', () => { renderMap(); renderHighest(); });
-    await renderMap();
-    await renderHighest();
+    const data: Snapshot = await fetch(`${import.meta.env.BASE_URL}data/town-analysis.json`).then((r) => {
+      if (!r.ok) throw new Error(`town-analysis.json ${r.status}`);
+      return r.json();
+    });
+    ($('sel-town') as HTMLSelectElement).innerHTML = data.towns.map((t) => `<option${t === data.default.town ? ' selected' : ''}>${t}</option>`).join('');
+    ($('sel-flat') as HTMLSelectElement).innerHTML = data.flatTypes.map((f) => `<option${f === data.default.flat ? ' selected' : ''}>${f}</option>`).join('');
+
+    // Paint immediately from JSON — no DuckDB needed for the default view.
+    paintMap(data.rows, data.default.town, data.default.flat);
+    paintHighest(data.highest);
+
+    // Filters go through DuckDB. Threshold-only changes just re-band the rows we
+    // already have, so they never touch the engine.
+    $('sel-town').addEventListener('change', loadMap);
+    $('sel-thr').addEventListener('change', () => paintMap(currentRows, currentTown, currentFlat));
+    $('sel-flat').addEventListener('change', () => { loadMap(); loadHighest(); });
+
+    warmEngineWhenIdle();
   })();
+
+  // Boot DuckDB in the background once the default view is up, so the first filter
+  // change is snappy — without competing with first paint. Skipped under Save-Data.
+  function warmEngineWhenIdle() {
+    if ((navigator as any).connection?.saveData) return;
+    const idle: (cb: () => void) => void =
+      (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
+    idle(() => {
+      _db = import('../lib/db');
+      _db.then((m) => m.prefetch()).catch(() => {});
+    });
+  }
 
   window.addEventListener('resize', () => { highestChart.resize(); map.invalidateSize(); });
 </script>

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -41,14 +41,15 @@ export default {
 };
 
 // `.wasm` comes from the brotli-compressed `<file>.br` asset, re-served with the
-// right encoding/type. Other engine files (workers) are small and pass through.
-// Missing assets fall back to jsDelivr so the engine still loads if a build ever
+// right encoding/type. This covers both the engine and the staged parquet extension
+// under /duckdb/<version>/ext/. Other engine files (workers) are small and pass
+// through. Missing assets fall back upstream so things still load if a build ever
 // skipped the compress step (also covers `wrangler dev` against an empty ./dist).
 async function serveEngine(request: Request, url: URL, env: Env): Promise<Response> {
   if (url.pathname.endsWith('.wasm')) {
     // Bare GET so the asset layer returns the raw brotli bytes rather than re-encoding.
     const asset = await env.ASSETS.fetch(new Request(`${url.origin}${url.pathname}.br`));
-    if (!asset.ok) return jsdelivrFallback(url.pathname);
+    if (!asset.ok) return upstreamFallback(url.pathname);
     return new Response(asset.body, {
       encodeBody: 'manual',
       headers: {
@@ -60,16 +61,22 @@ async function serveEngine(request: Request, url: URL, env: Env): Promise<Respon
   }
 
   const asset = await env.ASSETS.fetch(request);
-  if (!asset.ok) return jsdelivrFallback(url.pathname);
+  if (!asset.ok) return upstreamFallback(url.pathname);
   const headers = new Headers(asset.headers); // mutable copy; asset's are guarded
   headers.set('Cache-Control', IMMUTABLE);
   return new Response(asset.body, { status: asset.status, headers });
 }
 
-// "/duckdb/<version>/<file>" mirrors the npm layout -> jsDelivr's
-// "@<version>/dist/<file>". A 302 keeps the browser's fetch flowing; instantiation
-// follows redirects transparently.
-function jsdelivrFallback(pathname: string): Response {
+// Graceful fallback if a staged file is missing. Extension requests
+// (/duckdb/<version>/ext/<core>/<platform>/<name>) go to the upstream DuckDB
+// extension repo; everything else mirrors the npm layout on jsDelivr. A 302 keeps
+// the browser's fetch flowing; instantiation follows redirects transparently.
+function upstreamFallback(pathname: string): Response {
+  const extIdx = pathname.indexOf('/ext/');
+  if (extIdx !== -1) {
+    const rest = pathname.slice(extIdx + '/ext/'.length); // "<core>/<platform>/<name>"
+    return Response.redirect(`https://extensions.duckdb.org/${rest}`, 302);
+  }
   const key = pathname.slice('/duckdb/'.length); // "<version>/<file>"
   const slash = key.indexOf('/');
   if (slash === -1) return new Response('Not found', { status: 404 });

--- a/web/tests/extension.spec.ts
+++ b/web/tests/extension.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+// Guards that the parquet extension is self-hosted: read_parquet must work with
+// extensions.duckdb.org hard-blocked, loading the brotli-staged copy that
+// src/worker.ts serves (via SET custom_extension_repository + compress-duckdb.mjs).
+test('read_parquet uses the self-hosted extension, not extensions.duckdb.org', async ({ page }) => {
+  let upstreamHit = false;
+  await page.route(/extensions\.duckdb\.org/, (r) => {
+    upstreamHit = true;
+    return r.abort();
+  });
+
+  const extReq = page.waitForRequest(
+    /\/duckdb\/.*\/ext\/.*parquet\.duckdb_extension\.wasm$/,
+    { timeout: 45_000 },
+  );
+
+  await page.goto('/town-analysis/');
+  await expect(page.locator('#map-sub')).toContainText('Ang Mo Kio', { timeout: 20_000 });
+
+  // A filter change boots DuckDB and runs read_parquet → autoloads the extension.
+  await page.selectOption('#sel-town', 'BEDOK');
+
+  const req = await extReq;
+  const res = await req.response();
+  expect(res?.status(), 'extension served 200 from our origin').toBe(200);
+  expect(new URL(req.url()).host, 'extension is same-origin').toBe(new URL(page.url()).host);
+
+  // The query completed and re-rendered — proof the self-hosted extension loaded.
+  await expect(page.locator('#map-sub')).toContainText('Bedok', { timeout: 45_000 });
+  expect(upstreamHit, 'must never touch extensions.duckdb.org').toBe(false);
+});

--- a/web/tests/prefetch.spec.ts
+++ b/web/tests/prefetch.spec.ts
@@ -15,7 +15,7 @@ import { test, expect } from '@playwright/test';
 test('landing pre-warms the DuckDB engine on load, with no interaction', async ({ page }) => {
   const wasmReq = page.waitForRequest(/\/duckdb\/.*\/duckdb-eh\.wasm$/, { timeout: 45_000 });
   const manifestReq = page.waitForRequest(/\/data\/manifest\.json$/, { timeout: 45_000 });
-  const parquetReq = page.waitForRequest(/\/data\/resale-.*\.parquet$/, { timeout: 45_000 });
+  const parquetReq = page.waitForRequest(/\/data\/resale\.parquet$/, { timeout: 45_000 });
 
   await page.goto('/');
   // Deliberately NO clicks or typing — the warm must happen on its own.
@@ -36,6 +36,6 @@ test('landing pre-warms the DuckDB engine on load, with no interaction', async (
   //    fetch — and that the brotli-served wasm actually compiled.
   await manifestReq;
 
-  // 3. read_parquet(...) in the CREATE VIEW pulls shard data: full end-to-end boot.
+  // 3. read_parquet(...) in the CREATE VIEW pulls the data file: full end-to-end boot.
   await parquetReq;
 });

--- a/web/tests/town-analysis.spec.ts
+++ b/web/tests/town-analysis.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+// Guards the town-analysis perf win: the default view must paint from the precomputed
+// town-analysis.json snapshot, with DuckDB entirely off the load path. DuckDB is only
+// booted when the visitor changes a Town/Flat filter.
+
+test('default view renders from JSON even with DuckDB + parquet blocked', async ({ page }) => {
+  // Hard-block the engine and the data file. If the default view still renders fully,
+  // it provably does not depend on DuckDB — the whole point of the precompute.
+  await page.route(/\/duckdb\//, (r) => r.abort());
+  await page.route(/\/data\/resale\.parquet$/, (r) => r.abort());
+
+  await page.goto('/town-analysis/');
+
+  await expect(page.locator('#map-sub')).toContainText('Ang Mo Kio', { timeout: 20_000 });
+  await expect(page.locator('#map-sub')).toContainText('sales');
+  await expect(page.locator('#median-price')).not.toHaveText('—');
+  await expect(page.locator('#tbody-town tr').first()).toBeVisible();
+});
+
+test('changing the Town filter boots DuckDB and re-renders', async ({ page }) => {
+  await page.goto('/town-analysis/');
+  await expect(page.locator('#map-sub')).toContainText('Ang Mo Kio', { timeout: 20_000 });
+
+  // A filter change is the first thing that should ever hit the data file.
+  const parquet = page.waitForRequest(/\/data\/resale\.parquet$/, { timeout: 45_000 });
+  await page.selectOption('#sel-town', 'BEDOK');
+  await parquet;
+
+  await expect(page.locator('#map-sub')).toContainText('Bedok', { timeout: 45_000 });
+});

--- a/web/tests/wasm-single-fetch.spec.ts
+++ b/web/tests/wasm-single-fetch.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// Guards against the double download of the ~4.7 MB engine. psf-trends warms DuckDB on
+// load; that warm both downloads and instantiates the wasm. A stray <link rel="prefetch">
+// for the same wasm used to fire a SECOND download (the prefetch cache isn't reused by
+// the worker's instantiate fetch), so the engine came down twice. It must be exactly once.
+test('the engine wasm is downloaded exactly once on a page that boots on load', async ({ page }) => {
+  const wasmReqs: string[] = [];
+  page.on('request', (r) => {
+    if (/\/duckdb\/.*\/duckdb-eh\.wasm$/.test(r.url())) wasmReqs.push(r.url());
+  });
+
+  await page.goto('/psf-trends/');
+  // The data file is fetched only after a successful instantiate, so by now every
+  // wasm request that will happen has happened.
+  await page.waitForRequest(/\/data\/resale\.parquet$/, { timeout: 45_000 });
+  await page.waitForTimeout(300); // settle any late duplicate
+
+  expect(wasmReqs.length, `wasm fetched ${wasmReqs.length}x: ${JSON.stringify(wasmReqs)}`).toBe(1);
+});

--- a/webapp/update/emit_web.py
+++ b/webapp/update/emit_web.py
@@ -1,9 +1,14 @@
 """Emit web artifacts for the static frontend (see wireframes/REBUILD_PLAN.md).
 
 Reads the combined ``data/df.parquet`` (produced by ``convert.csv_to_parquet``) and
-writes year-sharded, ZSTD-compressed, column-trimmed Parquet into ``web/public/data/``
-along with a ``manifest.json``. Standalone (polars only) so it does not depend on the
-Streamlit-Cloud path baked into ``webapp.utils.get_project_root``.
+writes a single ZSTD-compressed, column-trimmed ``resale.parquet`` into
+``web/public/data/`` along with a ``manifest.json``. Standalone (polars only) so it
+does not depend on the Streamlit-Cloud path baked into ``webapp.utils.get_project_root``.
+
+The data is emitted as ONE file rather than year-shards: DuckDB-WASM reads it over HTTP
+range requests, and every query spans all years, so sharding only multiplied the
+sequential round-trips (footer + column reads per file) with no pruning benefit. A
+single file is read in one pass — far fewer requests, much faster first query.
 
 Also precomputes ``overview.json`` — the landing page's aggregates (price trends,
 distribution, lease relationship, recent transactions) so the landing renders from a
@@ -130,29 +135,22 @@ def emit() -> None:
     df = pl.read_parquet(SRC_PARQUET)
     df = df.drop([c for c in DROP_COLS if c in df.columns])
 
-    # year for sharding; sort so repeated low-cardinality values cluster (better compression)
-    df = df.with_columns(pl.col("month").str.slice(0, 4).alias("year")).sort(
-        ["town", "flat_type", "month"]
-    )
+    # Sort so repeated low-cardinality values cluster (better ZSTD compression) and so
+    # town-filtered queries can skip row groups via the town min/max statistics.
+    df = df.sort(["town", "flat_type", "month"])
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
+    # Clean up the old year-shards from previous builds so nothing stale is served.
     for old in OUT_DIR.glob("resale-*.parquet"):
         old.unlink()
 
-    years = sorted(df["year"].unique().to_list())
-    files = []
-    for year in years:
-        shard = df.filter(pl.col("year") == year).drop("year")
-        out = OUT_DIR / f"resale-{year}.parquet"
-        shard.write_parquet(
-            out,
-            compression="zstd",
-            compression_level=19,
-            row_group_size=shard.height or 1,
-            statistics=True,
-        )
-        files.append({"year": year, "file": out.name, "rows": shard.height,
-                      "bytes": out.stat().st_size})
+    out = OUT_DIR / "resale.parquet"
+    df.write_parquet(
+        out,
+        compression="zstd",
+        compression_level=19,
+        statistics=True,
+    )
 
     epoch = int(METADATA.read_text().strip()) if METADATA.exists() else None
     manifest = {
@@ -161,18 +159,22 @@ def emit() -> None:
         if epoch
         else None,
         "rows": df.height,
-        "years": years,
-        "shards": files,
-        "columns": df.drop("year").columns,
+        "file": out.name,
+        "bytes": out.stat().st_size,
+        "columns": df.columns,
     }
     (OUT_DIR / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
     emit_overview(df)
 
-    total = sum(f["bytes"] for f in files)
-    print(f"Wrote {len(files)} shards, {df.height:,} rows, {total/1e6:.2f} MB total")
-    for f in files:
-        print(f"  {f['file']:>18}  {f['rows']:>7,} rows  {f['bytes']/1e6:6.2f} MB")
+    size = out.stat().st_size
+    print(f"Wrote {out.name}, {df.height:,} rows, {size/1e6:.2f} MB")
+    # resale.parquet ships as a plain Cloudflare static asset, which caps individual
+    # files at 25 MiB. Warn well before that so growth doesn't silently break deploys;
+    # if we ever cross it, route the file through src/worker.ts (like the wasm) or R2.
+    if size > 20 * 1024 * 1024:
+        print(f"  WARNING: {out.name} is {size/1024/1024:.1f} MiB — approaching "
+              "Cloudflare's 25 MiB static-asset cap.")
 
 
 if __name__ == "__main__":

--- a/webapp/update/emit_web.py
+++ b/webapp/update/emit_web.py
@@ -10,10 +10,11 @@ range requests, and every query spans all years, so sharding only multiplied the
 sequential round-trips (footer + column reads per file) with no pruning benefit. A
 single file is read in one pass — far fewer requests, much faster first query.
 
-Also precomputes ``overview.json`` — the landing page's aggregates (price trends,
-distribution, lease relationship, recent transactions) so the landing renders from a
-single small fetch instead of booting DuckDB-WASM in the browser. The queries here
-mirror the SQL in ``web/src/pages/index.astro`` one-for-one so the numbers stay identical.
+Also precomputes ``overview.json`` (landing page) and ``town-analysis.json`` (the
+town-analysis default view) so those pages paint from a single small fetch instead of
+booting DuckDB-WASM in the browser on load. The queries here mirror the SQL in the
+corresponding page one-for-one so the numbers stay identical; DuckDB is only booted
+in the browser when the visitor changes a filter.
 """
 
 from __future__ import annotations
@@ -28,6 +29,11 @@ ROOT = Path(__file__).resolve().parents[2]
 SRC_PARQUET = ROOT / "data" / "df.parquet"
 METADATA = ROOT / "data" / "metadata"
 OUT_DIR = ROOT / "web" / "public" / "data"
+
+# Default view the town-analysis page renders on load. MUST match the DEFAULT_TOWN /
+# DEFAULT_FLAT constants in web/src/pages/town-analysis.astro.
+TA_DEFAULT_TOWN = "ANG MO KIO"
+TA_DEFAULT_FLAT = "4 ROOM"
 
 # Columns dropped for the web: derivable or unused by any page.
 #   _id, _ts        — internal ETL bookkeeping
@@ -131,6 +137,62 @@ def emit_overview(df: pl.DataFrame) -> None:
     print(f"Wrote overview.json ({out.stat().st_size / 1024:.1f} KB)")
 
 
+def emit_town_analysis(df: pl.DataFrame) -> None:
+    """Precompute the town-analysis default view into town-analysis.json.
+
+    Mirrors the on-load queries in web/src/pages/town-analysis.astro: the town/flat
+    option lists, the default town/flat map rows (last 24 months), and the highest
+    recorded sale per town for the default flat. Rendering this lets the page paint
+    without DuckDB; the engine only boots when the visitor changes a filter.
+    """
+    today = date.today()
+    cutoff = f"{today.year - 2}-{today.month:02d}"  # 'YYYY-MM', 24 months back
+
+    # Map rows for the default town/flat — mirrors renderMap()'s SELECT one-for-one.
+    rows = (
+        df.filter(
+            (pl.col("town") == TA_DEFAULT_TOWN)
+            & (pl.col("flat_type") == TA_DEFAULT_FLAT)
+            & (pl.col("month") >= cutoff)
+            & pl.col("latitude").is_not_null()
+        )
+        .sort(["month", "resale_price"], descending=[True, True])
+        .select(
+            pl.col("latitude").alias("lat"),
+            pl.col("longitude").alias("lng"),
+            pl.col("resale_price").alias("price"),
+            "address",
+            "month",
+            pl.col("storey_range").alias("storey"),
+            "psf",
+            pl.col("remaining_lease_years").alias("lease"),
+        )
+        .to_dicts()
+    )
+
+    # Highest sale per town for the default flat — mirrors renderHighest()'s query.
+    highest = (
+        df.filter(pl.col("flat_type") == TA_DEFAULT_FLAT)
+        .group_by("town")
+        .agg(pl.col("resale_price").max().alias("mx"))
+        .sort("mx", descending=True)
+        .head(15)
+        .select(["town", "mx"])
+        .to_dicts()
+    )
+
+    payload = {
+        "default": {"town": TA_DEFAULT_TOWN, "flat": TA_DEFAULT_FLAT},
+        "towns": sorted(df["town"].unique().to_list()),
+        "flatTypes": sorted(df["flat_type"].unique().to_list()),
+        "rows": rows,
+        "highest": highest,
+    }
+    out = OUT_DIR / "town-analysis.json"
+    out.write_text(json.dumps(payload))
+    print(f"Wrote town-analysis.json ({out.stat().st_size / 1024:.1f} KB)")
+
+
 def emit() -> None:
     df = pl.read_parquet(SRC_PARQUET)
     df = df.drop([c for c in DROP_COLS if c in df.columns])
@@ -166,6 +228,7 @@ def emit() -> None:
     (OUT_DIR / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
     emit_overview(df)
+    emit_town_analysis(df)
 
     size = out.stat().st_size
     print(f"Wrote {out.name}, {df.height:,} rows, {size/1e6:.2f} MB")


### PR DESCRIPTION
Diagnosis of the slow `town-analysis` load: **~5.3s to first view**, dominated by DuckDB reading parquet. Measured waterfall on the preview deploy showed **30 sequential HTTP range requests** walking 10 shards (2.3s→5.2s), a cross-origin parquet-extension fetch, and the 4.7 MB engine downloaded twice.

Each fix is an atomic commit with an E2E guard.

> **Stacked on #13** (`fix/duckdb-prefetch`) — base is that branch, so this diff shows only the perf commits. Merge #13 first (or retarget to `main` once it lands).

### 1. One `resale.parquet` instead of 10 year-shards (`c6dc878`)
Every query spans all years, so sharding only multiplied round-trips (footer + columns × 10 files, walked sequentially) with no pruning benefit. One ZSTD file, sorted by town for row-group pruning: **235,852 rows → 3.58 MB** (smaller than the 4.5 MB sharded), read in a single pass. Build-time warning if it ever nears Cloudflare's 25 MiB static-asset cap.

### 2. Precompute the town-analysis default view (`5492f87`)
The page booted DuckDB on load just to populate selects + render the default ANG MO KIO / 4-ROOM view. Now it paints from a **~116 KB `town-analysis.json`** (same pattern as the landing's `overview.json`) with **zero DuckDB on the load path**; the engine warms on idle so the first filter change stays snappy. Threshold changes just re-band the rows in hand.

### 3. Self-host the parquet extension (`16a54e6`)
`read_parquet` autoloaded the extension cross-origin from `extensions.duckdb.org` (~0.5s + a third-party runtime dependency). Now staged brotli at build and served same-origin via `SET custom_extension_repository` (rides the existing `worker.ts` `/duckdb/*.wasm` path). Graceful fallback to upstream if a staged file is ever missing.

### 4. Stop double-downloading the engine wasm (`12302df`)
`psf-trends` / `my-flat-insights` eagerly warm DuckDB (which downloads + instantiates the wasm) **and** declared `<link rel="prefetch">` for the same 4.7 MB wasm — the prefetch cache isn't reused by the worker's instantiate fetch, so it came down twice. Dropped the redundant link.

## Net effect on town-analysis load
- **Before:** 4.7 MB wasm ×2 + cross-origin extension + ~30 parquet range requests across 10 files → ~5.3s to first view.
- **After:** first view paints from a 116 KB JSON with **no engine and no parquet on the load path**; DuckDB warms in the background; a filter change then hits a single same-origin file with a self-hosted extension and one wasm download.

## Tests (all via `wrangler dev` — the real worker + brotli path)
- `town-analysis.spec.ts` — default view renders with **DuckDB + parquet hard-blocked** (proves independence); a Town filter change boots the engine.
- `extension.spec.ts` — `read_parquet` works with **`extensions.duckdb.org` blocked** (proves self-hosting).
- `wasm-single-fetch.spec.ts` — engine wasm fetched **exactly once** (verified it fails at 2× with the link restored).
- `prefetch.spec.ts` — updated for the single data file.

All 5 pass. Each guard was confirmed to go red against the pre-fix behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)