### PR TITLE
fix(web): add mobile nav menu

### DIFF
--- a/web/src/components/Nav.astro
+++ b/web/src/components/Nav.astro
@@ -16,10 +16,37 @@ const links = [
 <header class="nav">
   <div class="wrap nav-in">
     <a class="brand" href="/"><span class="key">🔑</span> HDB&nbsp;Kaki</a>
-    <nav class="nav-links">
+    <button
+      class="nav-toggle"
+      type="button"
+      aria-label="Toggle navigation menu"
+      aria-expanded="false"
+      aria-controls="nav-links"
+    >
+      <span class="nav-toggle-bar"></span>
+      <span class="nav-toggle-bar"></span>
+      <span class="nav-toggle-bar"></span>
+    </button>
+    <nav class="nav-links" id="nav-links">
       {links.map((l) => (
         <a href={l.href} class={l.label === active ? 'active' : ''}>{l.label}</a>
       ))}
     </nav>
   </div>
 </header>
+
+<script>
+  const toggle = document.querySelector<HTMLButtonElement>('.nav-toggle');
+  const nav = document.querySelector<HTMLElement>('.nav-links');
+  toggle?.addEventListener('click', () => {
+    const open = document.body.classList.toggle('nav-open');
+    toggle.setAttribute('aria-expanded', String(open));
+  });
+  // Close the menu after tapping a link (in-page nav or new page load).
+  nav?.addEventListener('click', (e) => {
+    if ((e.target as HTMLElement).closest('a')) {
+      document.body.classList.remove('nav-open');
+      toggle?.setAttribute('aria-expanded', 'false');
+    }
+  });
+</script>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -35,6 +35,18 @@ header.nav{
 .nav-links a{color:inherit;text-decoration:none}
 .nav-links a.active{color:var(--ink);font-weight:600}
 .nav-links a:hover{color:var(--red-ink)}
+/* Hamburger toggle — hidden on desktop, shown in the mobile media query. */
+.nav-toggle{
+  display:none;width:40px;height:40px;padding:0;border:0;background:transparent;
+  cursor:pointer;flex-direction:column;justify-content:center;align-items:center;gap:5px
+}
+.nav-toggle-bar{
+  display:block;width:22px;height:2px;border-radius:2px;background:var(--ink);
+  transition:transform .2s ease,opacity .2s ease
+}
+body.nav-open .nav-toggle-bar:nth-child(1){transform:translateY(7px) rotate(45deg)}
+body.nav-open .nav-toggle-bar:nth-child(2){opacity:0}
+body.nav-open .nav-toggle-bar:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
 
 /* ---------- hero ---------- */
 .hero{padding:52px 0 64px}
@@ -132,7 +144,17 @@ table.comp tbody tr:hover{background:#faf6ee}
 
 /* ---------- responsive ---------- */
 @media(max-width:900px){
-  .nav-links{display:none}
+  .nav-toggle{display:flex}
+  .nav-links{
+    display:flex;flex-direction:column;gap:0;
+    position:absolute;top:66px;left:0;right:0;
+    background:var(--paper);border-bottom:1px solid var(--line);
+    box-shadow:0 12px 24px -12px rgba(0,0,0,.2);
+    max-height:0;overflow:hidden;visibility:hidden;
+    transition:max-height .25s ease,visibility .25s ease
+  }
+  .nav-links a{padding:15px 24px;border-top:1px solid var(--line);font-size:16px}
+  body.nav-open .nav-links{max-height:80vh;visibility:visible}
   .split{grid-template-columns:1fr !important}
   .bench-grid{grid-template-columns:1fr}
   .sec-head .hint{display:none}


### PR DESCRIPTION
## Problem
On any screen ≤900px (i.e. every phone), the nav links were hidden with `display:none` and **nothing replaced them** — no hamburger, no menu. The only tappable nav element was the 🔑 brand logo (which just reloads home), so **Town Analysis, PSF Trends, and My Flat Insights were unreachable on mobile**.

## Fix
- `Nav.astro` — add an accessible hamburger `<button>` (`aria-expanded` / `aria-controls`) and a small script that toggles a `body.nav-open` class and auto-closes after a link is tapped.
- `global.css` — toggle is hidden on desktop; on ≤900px it appears and animates into an X, and `.nav-links` becomes a full-width dropdown panel. Desktop nav untouched.

## Verification
Driven in a headless browser at an iPhone 13 viewport:
- hamburger visible on mobile ✓
- links hidden until tapped ✓
- `aria-expanded` flips false→true ✓
- links appear on tap ✓
- tapping "Town Analysis" navigates to `/town-analysis` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)