### PR TITLE
fix(web): let data tables scroll horizontally on mobile

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -76,7 +76,7 @@ try {
     <!-- 04 · RECENT TRANSACTIONS -->
     <div class="sec-head"><span class="num">04</span><h2>Recent transactions</h2>
       <span class="hint">Latest registered resale deals.</span></div>
-    <div class="card" style="overflow:hidden">
+    <div class="card table-card">
       <table class="comp">
         <thead><tr>
           <th>Sold</th><th>Town</th><th>Address</th><th>Type</th>

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -203,7 +203,7 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
   .decay .now::after{content:attr(data-label);position:absolute;top:-1px;left:8px;font-size:11px;font-weight:600;background:var(--ink);color:#fff;padding:2px 7px;border-radius:6px;white-space:nowrap}
   .decay .ticks{position:absolute;inset:0;display:flex;justify-content:space-between;padding:0 10px;align-items:center;font-size:10.5px;color:#7a7264;font-family:'IBM Plex Mono'}
   /* comps */
-  .comp-wrap{overflow:hidden}
+  .comp-wrap{overflow-x:auto;overflow-y:hidden;-webkit-overflow-scrolling:touch}
   /* :global — comparables rows are injected via innerHTML */
   :global(.addr b){font-weight:600}
   :global(.addr .st){color:var(--ink-3);font-size:12.5px}

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -51,7 +51,7 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
 
     <div class="sec-head"><span class="num">02</span><h2>Fitted PSF by month</h2>
       <span class="hint">Trend value read off the fit for each month.</span></div>
-    <div class="card" style="overflow:hidden">
+    <div class="card table-card">
       <table class="comp">
         <thead><tr><th>Month</th><th class="r">Trend PSF</th><th class="r">MoM change</th></tr></thead>
         <tbody id="tbody-psf"><tr><td colspan="3" style="padding:22px 16px;color:var(--ink-3)">Loading…</td></tr></tbody>

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -60,7 +60,7 @@ import { ehWasmUrl } from '../lib/duckdbBundle';
     <!-- 03 · DATA TABLE -->
     <div class="sec-head"><span class="num">03</span><h2>Data behind the map</h2>
       <span class="hint">Every point currently in view.</span></div>
-    <div class="card" style="overflow:hidden">
+    <div class="card table-card">
       <table class="comp">
         <thead><tr><th>Sold</th><th>Address</th><th class="r">Price</th><th class="r">PSF</th><th class="r">Lease left</th><th>Band</th></tr></thead>
         <tbody id="tbody-town"><tr><td colspan="6" style="padding:22px 16px;color:var(--ink-3)">Loading…</td></tr></tbody>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -132,6 +132,10 @@ footer{border-top:1px solid var(--line);padding:26px 0;color:var(--ink-3);font-s
 .chart-title{font-family:'Fraunces';font-weight:600;font-size:18px}
 
 /* ---------- tables ---------- */
+/* Table cards scroll horizontally on narrow screens instead of clipping the
+   right-hand columns (Price/PSF were unreachable on mobile). Rounded corners
+   are still clipped via overflow-y. */
+.card.table-card{overflow-x:auto;overflow-y:hidden;-webkit-overflow-scrolling:touch}
 table.comp{width:100%;border-collapse:collapse;font-size:14px}
 table.comp thead th{text-align:left;font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-3);padding:14px 16px;border-bottom:1px solid var(--line);background:#faf6ee}
 table.comp thead th.r,table.comp td.r{text-align:right}


### PR DESCRIPTION
Follow-up to #16 (which was already merged, so this lands as a separate PR).

## Problem
Every data table sat in a card with `overflow:hidden`. On a ~390px screen the tables are 518–676px wide, so the right-hand columns were **clipped with no way to scroll to them**:

| Page | Table | Hidden on mobile |
|------|-------|------------------|
| Home | Recent transactions | Type, Area, **Price, PSF** |
| Town Analysis | Data behind the map | **Price, PSF**, Lease left, Band |
| My Flat Insights | Nearby comparables | **Price** |
| PSF Trends | Fitted PSF by month | borderline |

Price/PSF being invisible is a real problem for a resale-price site.

## Fix
Switch the table cards to `overflow-x:auto` (with `overflow-y:hidden` to keep the rounded corners, plus `-webkit-overflow-scrolling:touch` for iOS momentum). Columns become swipeable; desktop layout is unchanged.

## Verification
Driven headless at an iPhone 13 viewport:
- all three tables report `scrollWidth > clientWidth` and scroll ✓
- scrolling to the right reveals Type/Area/Price/PSF, rendered correctly ✓
- no page-level horizontal overflow introduced ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)