### PR TITLE
feat(web): hero KPI strip (Redfin-style) + left-aligned section decks

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import { trendsSVG } from '../lib/echartsSSR';
+import { moneyShort, psf as fpsf } from '../lib/format';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -9,14 +10,31 @@ const base = import.meta.env.BASE_URL;
 // SSR the hero chart to inline SVG so it paints instantly — no JS, no fetch. The
 // client swaps in the interactive canvas chart after hydration. Falls back to a
 // client-only render if overview.json hasn't been generated yet (e.g. fresh clone).
+type Kpi = { value: number | null; yoy: number | null };
+type Stats = { medianPrice: Kpi; txns: Kpi; millionDollar: Kpi; medianPsf: Kpi };
 let heroSVG = '';
+let stats: Stats | null = null;
 try {
   const path = fileURLToPath(new URL('../../public/data/overview.json', import.meta.url));
   const ov = JSON.parse(fs.readFileSync(path, 'utf8'));
   heroSVG = trendsSVG(ov.trends.lease, 1040, 380);
+  stats = ov.stats ?? null;
 } catch {
   heroSVG = '';
 }
+
+// Redfin-style hero KPI strip: a headline value + its year-on-year delta each.
+const int = (n: number | null) => (n == null ? '—' : n.toLocaleString('en-SG'));
+const dCls = (n: number | null) => (n == null ? 'flat' : n >= 0 ? 'up' : 'down');
+const dTxt = (n: number | null) => (n == null ? 'n/a' : `${n >= 0 ? '▲' : '▼'} ${Math.abs(n).toFixed(1)}% YoY`);
+const kpis = stats
+  ? [
+      { cap: 'Median resale price', val: stats.medianPrice.value == null ? '—' : moneyShort(stats.medianPrice.value), yoy: stats.medianPrice.yoy },
+      { cap: 'Transactions · 12 mo', val: int(stats.txns.value), yoy: stats.txns.yoy },
+      { cap: 'Million-dollar flats · 12 mo', val: int(stats.millionDollar.value), yoy: stats.millionDollar.yoy },
+      { cap: 'Median PSF', val: stats.medianPsf.value == null ? '—' : fpsf(stats.medianPsf.value), yoy: stats.medianPsf.yoy },
+    ]
+  : [];
 ---
 
 <Base active="Resale Visualizations" title="Resale Visualizations — HDB Kaki">
@@ -30,6 +48,17 @@ try {
         Median prices, distributions and lease dynamics across every HDB resale transaction
         since 2017 — refreshed daily from data.gov.sg.
       </p>
+      {stats && (
+        <div class="kpi-strip rise" style="animation-delay:.15s" aria-label="Market at a glance, last 12 months">
+          {kpis.map((k) => (
+            <div class="kpi">
+              <span class="kpi-cap">{k.cap}</span>
+              <span class="kpi-val mono">{k.val}</span>
+              <span class={`pill ${dCls(k.yoy)}`}>{dTxt(k.yoy)}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   </section>
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -64,6 +64,16 @@ h1.title em{font-style:italic;color:var(--red-ink)}
 .lede{font-size:18px;color:var(--ink-2);max-width:52ch}
 .hero-actions{display:flex;gap:14px;margin-top:28px;flex-wrap:wrap}
 
+/* Hero KPI strip — Redfin-style row of headline metrics under the lede, each a
+   last-12-month value with its own year-on-year delta. */
+.kpi-strip{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:34px}
+.kpi{
+  background:var(--paper-2);border:1px solid var(--line);border-radius:var(--radius);
+  box-shadow:var(--shadow);padding:18px 20px;display:flex;flex-direction:column;align-items:flex-start;gap:9px;
+}
+.kpi-cap{font-size:12.5px;color:var(--ink-3);letter-spacing:.01em}
+.kpi-val{font-weight:600;font-size:clamp(24px,2.6vw,30px);line-height:1;letter-spacing:-.01em;color:var(--ink)}
+
 /* ---------- buttons ---------- */
 .cta{
   font-family:'Public Sans';font-weight:600;font-size:15px;color:#fff;background:var(--ink);
@@ -92,10 +102,12 @@ footer{border-top:1px solid var(--line);padding:26px 0;color:var(--ink-3);font-s
 }
 
 /* ---------- section headers ---------- */
-.sec-head{display:flex;align-items:baseline;gap:14px;margin:44px 0 20px}
-.sec-head .num{font-family:'IBM Plex Mono';font-size:13px;color:var(--red-ink);font-weight:600;padding-top:4px}
-.sec-head h2{font-family:'Fraunces';font-weight:600;font-size:27px;letter-spacing:-.02em}
-.sec-head .hint{margin-left:auto;font-size:13px;color:var(--ink-3);max-width:40ch;text-align:right}
+/* Number in the gutter; heading and its deck stack in the second column so the
+   deck reads as an intro under the title (left-aligned) rather than a floated caption. */
+.sec-head{display:grid;grid-template-columns:auto 1fr;column-gap:14px;align-items:baseline;margin:44px 0 20px}
+.sec-head .num{grid-column:1;font-family:'IBM Plex Mono';font-size:13px;color:var(--red-ink);font-weight:600;padding-top:4px}
+.sec-head h2{grid-column:2;font-family:'Fraunces';font-weight:600;font-size:27px;letter-spacing:-.02em}
+.sec-head .hint{grid-column:2;margin-top:8px;font-size:14.5px;color:var(--ink-2);max-width:62ch}
 
 /* ---------- cards ---------- */
 .card{background:var(--paper-2);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
@@ -158,4 +170,5 @@ table.comp tbody tr:hover{background:#faf6ee}
   .split{grid-template-columns:1fr !important}
   .bench-grid{grid-template-columns:1fr}
   .sec-head .hint{display:none}
+  .kpi-strip{grid-template-columns:1fr 1fr;gap:12px}
 }

--- a/webapp/update/emit_web.py
+++ b/webapp/update/emit_web.py
@@ -109,6 +109,24 @@ def emit_overview(df: pl.DataFrame) -> None:
         .to_dicts()
     )
 
+    # ---- landing KPI strip (Redfin-style) ----
+    # Four headline metrics for the hero, each a last-12-month value paired with a
+    # year-on-year delta against the preceding 12 months (recent_window vs prev_window).
+    prev_cutoff = f"{today.year - 2}-{today.month:02d}"  # 24 months back
+    prev_window = df.filter((pl.col("month") >= prev_cutoff) & (pl.col("month") < cutoff))
+
+    def _kpi(now: float | None, prev: float | None) -> dict:
+        yoy = (now - prev) / prev * 100 if (now is not None and prev) else None
+        return {"value": now, "yoy": yoy}
+
+    million = pl.col("resale_price") >= 1_000_000
+    stats = {
+        "medianPrice": _kpi(recent_window["resale_price"].median(), prev_window["resale_price"].median()),
+        "txns": _kpi(recent_window.height, prev_window.height),
+        "millionDollar": _kpi(recent_window.filter(million).height, prev_window.filter(million).height),
+        "medianPsf": _kpi(recent_window["psf"].median(), prev_window["psf"].median()),
+    }
+
     overview = {
         "trends": {
             "lease": trend("cat_remaining_lease_years"),
@@ -120,6 +138,7 @@ def emit_overview(df: pl.DataFrame) -> None:
         "buckets": buckets,
         "recent": recent,
         "recentTotal": recent_window.height,
+        "stats": stats,
     }
     out = OUT_DIR / "overview.json"
     out.write_text(json.dumps(overview))


### PR DESCRIPTION
## What & why

Two design refinements to the landing page, from a review of the current layout. (Deliberately scoped — legend/toggle/axis tweaks from the same review were left out per feedback.)

### 1. Hero KPI strip (Redfin-style)
The hero's right column was empty (~40% of above-the-fold space). Rather than a side panel, the hero now carries a **full-width KPI strip** under the lede — the pattern Redfin/Zillow/PropKaki lead with. Four headline metrics, each a **last-12-month value with its own year-on-year delta**:

- **Median resale price**
- **Transactions** (last 12 mo)
- **Million-dollar flats** (last 12 mo) — newsworthy, on-theme, and a one-line filter on the data
- **Median PSF**

Figures are precomputed into `overview.json` (`emit_web.py`) and rendered at **build time (SSR)** — the strip paints with no client JS and no fetch, matching how the hero chart already works. The strip is hidden gracefully when `overview.json` is absent (fresh clone / no data).

### 2. Section decks left-aligned under the heading
The `.hint` deck text was floated small and right-aligned, fighting the left-aligned heading. It now sits left-aligned directly under its heading, slightly larger and darker. This touches the **shared `.sec-head` component**, so all four pages (Resale, Town Analysis, PSF Trends, My Flat Insights) get the consistent treatment.

## Stat selection
Researched what real-estate trackers surface (Redfin/Zillow + SG portals). Chose the four above from what this dataset can actually compute; **days on market / inventory / months supply / % above list / COV** were ruled out — they need listing/valuation data not in data.gov.sg. Full comparison + hero-layout alternatives are in `wireframes/2026-07-18-hero-alternatives.html`.

## Testing
- `astro build` passes; verified the SSR'd strip renders correct values and per-tile deltas against a synthetic `overview.json`.
- Responsive: strip is 4-up on desktop, 2-up at ≤900px (where section decks are already hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)