### PR TITLE
fix(web): anchor precomputed rolling windows to data date

### DIFF
--- a/.github/workflows/etl.yaml
+++ b/.github/workflows/etl.yaml
@@ -58,7 +58,8 @@ jobs:
         git config user.name 'GitHub Actions'
         git config user.email 'actions@github.com'
 
-        echo $(date +%s) > data/metadata
+        # data/metadata (the last-updated stamp) is written by etl.py when the data
+        # changed; here we just stage and commit it alongside the refreshed CSVs.
         git add data/*.csv data/metadata
 
         git commit -m "chore: update data"

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -117,6 +117,10 @@ import Base from '../layouts/Base.astro';
   type Hi = { town: string; mx: number };
   let currentRows: Row[] = [];
   let currentTown = DEFAULT_TOWN;
+  // The "last 24 months" cutoff ('YYYY-MM'), shipped in the snapshot so the live
+  // re-query below uses the exact window the JSON was precomputed from (anchored to
+  // the data's last-updated month, not wall-clock). Assigned once the snapshot loads.
+  let cutoff = '';
   let currentFlat = DEFAULT_FLAT;
 
   // ---- Leaflet map (created once) ----
@@ -187,7 +191,8 @@ import Base from '../layouts/Base.astro';
   }
 
   // Fetch rows for the current town/flat from DuckDB, then paint. Mirrors the SQL the
-  // default snapshot was precomputed from (see webapp/update/emit_web.py).
+  // default snapshot was precomputed from (see webapp/update/emit_web.py) — including
+  // the same `cutoff` window, so the live query and the default snapshot agree.
   async function loadMap() {
     const town = (($('sel-town') as HTMLSelectElement).value) || DEFAULT_TOWN;
     const flat = ($('sel-flat') as HTMLSelectElement).value;
@@ -196,7 +201,7 @@ import Base from '../layouts/Base.astro';
               storey_range storey, psf, remaining_lease_years lease
        FROM resale
        WHERE town='${sql(town)}' AND flat_type='${sql(flat)}'
-         AND month >= strftime(current_date - INTERVAL 24 MONTH, '%Y-%m')
+         AND month >= '${cutoff}'
          AND latitude IS NOT NULL
        ORDER BY month DESC, resale_price DESC`,
     ).then((rs) => rs.map((r) => ({ ...r, price: Number(r.price), psf: Number(r.psf), lat: Number(r.lat), lng: Number(r.lng), lease: Number(r.lease) })));
@@ -248,12 +253,18 @@ import Base from '../layouts/Base.astro';
   });
 
   // ---- boot: paint the default view from the precomputed snapshot, then wire filters ----
-  type Snapshot = { default: { town: string; flat: string }; towns: string[]; flatTypes: string[]; rows: Row[]; highest: Hi[] };
+  type Snapshot = { default: { town: string; flat: string }; cutoff?: string; towns: string[]; flatTypes: string[]; rows: Row[]; highest: Hi[] };
   (async () => {
     const data: Snapshot = await fetch(`${import.meta.env.BASE_URL}data/town-analysis.json`).then((r) => {
       if (!r.ok) throw new Error(`town-analysis.json ${r.status}`);
       return r.json();
     });
+    // Reuse the snapshot's cutoff so live re-queries match it exactly. Fall back to a
+    // wall-clock 24-month window only if an older snapshot without the field is served.
+    cutoff = data.cutoff ?? (() => {
+      const d = new Date(); d.setMonth(d.getMonth() - 24);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    })();
     ($('sel-town') as HTMLSelectElement).innerHTML = data.towns.map((t) => `<option${t === data.default.town ? ' selected' : ''}>${t}</option>`).join('');
     ($('sel-flat') as HTMLSelectElement).innerHTML = data.flatTypes.map((f) => `<option${f === data.default.flat ? ' selected' : ''}>${f}</option>`).join('');
 

--- a/webapp/update/emit_web.py
+++ b/webapp/update/emit_web.py
@@ -56,15 +56,16 @@ def _quarter_expr() -> pl.Expr:
     return (year + pl.lit(" Q") + quarter).alias("quarter")
 
 
-def emit_overview(df: pl.DataFrame) -> None:
+def emit_overview(df: pl.DataFrame, anchor: date) -> None:
     """Precompute the four landing-page charts + recent table into overview.json.
 
     Each block mirrors the corresponding query in web/src/pages/index.astro. The
-    12-month window uses today's date (recomputed each ETL run), matching the app's
-    original ``current_date - INTERVAL 12 MONTH`` behaviour.
+    12-month window is measured back from ``anchor`` — the data's last-updated date
+    (data/metadata), not wall-clock — so it tracks the data's own age and stays put
+    on days the data doesn't change. The landing page renders entirely from this JSON
+    with no client-side re-query, so the window can never diverge in the browser.
     """
-    today = date.today()
-    cutoff = f"{today.year - 1}-{today.month:02d}"  # 'YYYY-MM', 12 months back
+    cutoff = f"{anchor.year - 1}-{anchor.month:02d}"  # 'YYYY-MM', 12 months back
 
     def trend(col: str) -> list[dict]:
         return (
@@ -143,16 +144,20 @@ def emit_overview(df: pl.DataFrame) -> None:
     print(f"Wrote overview.json ({out.stat().st_size / 1024:.1f} KB)")
 
 
-def emit_town_analysis(df: pl.DataFrame) -> None:
+def emit_town_analysis(df: pl.DataFrame, anchor: date) -> None:
     """Precompute the town-analysis default view into town-analysis.json.
 
     Mirrors the on-load queries in web/src/pages/town-analysis.astro: the town/flat
     option lists, the default town/flat map rows (last 24 months), and the highest
     recorded sale per town for the default flat. Rendering this lets the page paint
     without DuckDB; the engine only boots when the visitor changes a filter.
+
+    The 24-month window is measured back from ``anchor`` (the data's last-updated
+    date, not wall-clock) and the resolved ``cutoff`` is shipped in the JSON. The
+    page binds its live DuckDB re-query to that same cutoff, so the default snapshot
+    and a filter-triggered query resolve the identical window — they can't diverge.
     """
-    today = date.today()
-    cutoff = f"{today.year - 2}-{today.month:02d}"  # 'YYYY-MM', 24 months back
+    cutoff = f"{anchor.year - 2}-{anchor.month:02d}"  # 'YYYY-MM', 24 months back
 
     # Map rows for the default town/flat — mirrors renderMap()'s SELECT one-for-one.
     rows = (
@@ -189,6 +194,7 @@ def emit_town_analysis(df: pl.DataFrame) -> None:
 
     payload = {
         "default": {"town": TA_DEFAULT_TOWN, "flat": TA_DEFAULT_FLAT},
+        "cutoff": cutoff,  # 'YYYY-MM'; the page reuses this for its live re-query
         "towns": sorted(df["town"].unique().to_list()),
         "flatTypes": sorted(df["flat_type"].unique().to_list()),
         "rows": rows,
@@ -275,6 +281,12 @@ def emit() -> None:
     )
 
     epoch = int(METADATA.read_text().strip()) if METADATA.exists() else None
+    # Anchor the rolling windows to the data's last-updated date rather than wall-clock,
+    # so the precomputed snapshots and the browser's live re-query resolve the SAME
+    # window (see emit_town_analysis / town-analysis.astro) and staleness tracks the
+    # data's age, not how long ago the site was rebuilt. Falls back to today when the
+    # metadata stamp is absent (e.g. a fresh clone with no ETL run yet).
+    anchor = datetime.fromtimestamp(epoch, tz=timezone.utc).date() if epoch else date.today()
     manifest = {
         "lastUpdatedEpoch": epoch,
         "lastUpdated": datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%d")
@@ -287,8 +299,8 @@ def emit() -> None:
     }
     (OUT_DIR / "manifest.json").write_text(json.dumps(manifest, indent=2))
 
-    emit_overview(df)
-    emit_town_analysis(df)
+    emit_overview(df, anchor)
+    emit_town_analysis(df, anchor)
     emit_psf_trends(df)
 
     size = out.stat().st_size

--- a/webapp/update/etl.py
+++ b/webapp/update/etl.py
@@ -1,14 +1,22 @@
 import sys
+import time
 from pathlib import Path
 import polars as pl
 
 from webapp.read import get_project_root, schema
 from webapp.update.convert import csv_to_parquet
+from webapp.update.emit_web import METADATA, emit
 from webapp.update.extract import extract, get_timestamps
 
 
 def update_data():
-    """Executes ETL process"""
+    """Executes ETL process end-to-end: fetch → parquet → web artifacts.
+
+    Emitting the web artifacts here means a single ``etl.py`` run leaves
+    web/public/data ready to preview locally. In CI the deploy workflow re-emits
+    against the release parquet, but keeping it in one place makes the pipeline
+    correct from a single command.
+    """
     csv_file_glob: Path = get_project_root() / "data" / "*.csv"
     df = pl.read_csv(csv_file_glob, schema=schema)
 
@@ -17,7 +25,13 @@ def update_data():
     csv_to_parquet()
 
     if has_changed:
+        # Advance the data's last-updated stamp only when the CSVs actually changed, so
+        # the rolling-window anchor (read by emit_web below) tracks data age rather than
+        # wall-clock. Written before emit() so the manifest + window cutoffs pick it up.
+        METADATA.write_text(str(int(time.time())))
         print("Changes detected")
+
+    emit()
     sys.exit(0)
 
 


### PR DESCRIPTION
## Problem

The precomputed default views baked a **rolling window** at build time from wall-clock (`date.today()`): 12 months for the overview, 24 months for town-analysis. But the browser re-evaluated the *same* window at **view time** — `town-analysis.astro` used `current_date - INTERVAL 24 MONTH` when a filter changed.

So the default JSON snapshot and a filter-triggered live query resolved **different windows for identical filters**, and the divergence grew with every day the site wasn't rebuilt. The docstrings' promise that the precomputed SQL "mirrors the page one-for-one so the numbers stay identical" only held on build day.

## Fix

**Anchor both sides to the data's last-updated date** (`data/metadata`), not wall-clock:

- **`emit_web.py`** — derive a single `anchor` from the metadata epoch (fallback: today) and measure the overview (12mo) and town-analysis (24mo) windows from it. Ship the resolved `cutoff` in `town-analysis.json`.
- **`town-analysis.astro`** — bind the live DuckDB re-query to `data.cutoff` (`month >= '${cutoff}'`), with a wall-clock fallback only for older snapshots lacking the field. Default and live views now resolve the *identical* window and can't diverge; staleness tracks the data's own age.

**Wire emit into the ETL** so the pipeline is correct from one command:

- **`etl.py`** — write `data/metadata` when the CSVs changed, then run `emit()` at the end (covers local previews; CI's deploy still re-emits authoritatively).
- **`etl.yaml`** — drop the now-redundant metadata write; etl.py owns it.

`psf-trends` (fixed `2020-01` start) and `index.astro` (fully static from JSON, no client re-query) need no changes.

## Verification

- Ran emit locally: metadata epoch `2026-07-17` → anchor `2026-07` → `town-analysis.json` cutoff `2024-07` ✓, `manifest.lastUpdated` consistent.
- `etl.py` imports cleanly; `emit` callable.

> Note: based on `perf/duckdb-load-v2` (targets that branch, not `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)