### PR TITLE
Rename Resale Visualizations to Market Overview

### DIFF
--- a/web/src/components/Nav.astro
+++ b/web/src/components/Nav.astro
@@ -6,7 +6,7 @@ interface Props {
 const { active = '' } = Astro.props;
 
 const links = [
-  { label: 'Resale Visualizations', href: '/' },
+  { label: 'Market Overview', href: '/' },
   { label: 'Town Analysis', href: '/town-analysis' },
   { label: 'PSF Trends', href: '/psf-trends' },
   { label: 'My Flat Insights', href: '/my-flat-insights' },

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -10,7 +10,7 @@ interface Props {
   active?: string;
 }
 const {
-  title = 'HDB Kaki — Singapore HDB resale insights',
+  title = 'HDB Kaki | Singapore HDB resale insights',
   description = "Track Singapore's HDB resale market — median prices, PSF trends, and what your flat is really worth.",
   active = '',
 } = Astro.props;

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -19,7 +19,7 @@ try {
 }
 ---
 
-<Base active="Resale Visualizations" title="Resale Visualizations — HDB Kaki">
+<Base active="Market Overview" title="Market Overview | HDB Kaki">
   <!-- Start the data fetch during HTML parse, parallel to the JS, so charts paint sooner. -->
   <link slot="head" rel="preload" as="fetch" href={`${base}data/overview.json`} crossorigin="anonymous" />
   <section class="hero">

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -2,7 +2,7 @@
 import Base from '../layouts/Base.astro';
 ---
 
-<Base active="My Flat Insights" title="My Flat Insights — HDB Kaki">
+<Base active="My Flat Insights" title="My Flat Insights | HDB Kaki">
   <!-- This page auto-computes a default valuation on load, so the script eagerly warms
        the same-origin DuckDB engine. That warm downloads + instantiates the wasm, so we
        deliberately do NOT also <link rel="prefetch"> it — that only double-downloaded

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -2,7 +2,7 @@
 import Base from '../layouts/Base.astro';
 ---
 
-<Base active="PSF Trends" title="PSF Trends — HDB Kaki">
+<Base active="PSF Trends" title="PSF Trends | HDB Kaki">
   <!-- The default view paints from a precomputed JSON snapshot (psf-trends.json), so
        DuckDB is NOT on the load path — the engine is warmed on idle and only booted when
        the visitor changes a filter or zooms. No <link rel="prefetch"> for the wasm: the

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -2,7 +2,7 @@
 import Base from '../layouts/Base.astro';
 ---
 
-<Base active="Town Analysis" title="Town Analysis — HDB Kaki">
+<Base active="Town Analysis" title="Town Analysis | HDB Kaki">
   <!-- The default view paints from a precomputed JSON snapshot (town-analysis.json),
        so DuckDB is NOT on the load path — the engine is warmed on idle and only booted
        when the visitor changes a filter. -->


### PR DESCRIPTION
## Summary
- Rename the landing page from **Resale Visualizations** to **Market Overview** (nav label + page title)
- Switch all page title separators from an em dash (`—`) to a pipe (`|`) for consistency

## Changes
- `web/src/components/Nav.astro` — nav label
- `web/src/pages/index.astro` — `active` prop + `<title>`
- `web/src/pages/{town-analysis,psf-trends,my-flat-insights}.astro` — title separators
- `web/src/layouts/Base.astro` — default fallback title separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)