### PR TITLE
perf(web): prefetch nav + client prerender for light pages

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -44,6 +44,16 @@ const duckdbDevFallback = {
 // Workers, GitHub Pages, etc. See wireframes/REBUILD_PLAN.md.
 export default defineConfig({
   site: 'https://app.hdb-kaki.workers.dev',
+  // Nav links are plain <a>; prefetch warms the next page on hover so cross-page
+  // nav feels instant. prefetchAll opts every internal link in by default — the two
+  // heavy map pages opt back out with data-astro-prefetch="false" in Nav.astro.
+  prefetch: { prefetchAll: true, defaultStrategy: 'hover' },
+  // Upgrade hover-prefetch to a full client-side prerender via the Speculation Rules
+  // API, so an opted-in link renders before the click. Pairs with the "warm on idle"
+  // engine priming — but the DuckDB warm on / and /psf-trends is gated behind
+  // document.prerendering so a hover can't pull the ~4.7 MB wasm for a page never
+  // visited, and the Leaflet map pages are excluded from prefetch entirely.
+  experimental: { clientPrerender: true },
   vite: {
     define: {
       'import.meta.env.PUBLIC_DUCKDB_VERSION': JSON.stringify(duckdbVersion),

--- a/web/src/components/Nav.astro
+++ b/web/src/components/Nav.astro
@@ -5,11 +5,14 @@ interface Props {
 }
 const { active = '' } = Astro.props;
 
+// `noPrefetch` opts a link out of prefetch (and, with experimental.clientPrerender,
+// out of speculative prerender). The two map pages eagerly import Leaflet, so a hover
+// shouldn't pull that engine for a page never visited — the lighter pages stay opted in.
 const links = [
   { label: 'Market Overview', href: '/' },
-  { label: 'Town Analysis', href: '/town-analysis' },
+  { label: 'Town Analysis', href: '/town-analysis', noPrefetch: true },
   { label: 'PSF Trends', href: '/psf-trends' },
-  { label: 'My Flat Insights', href: '/my-flat-insights' },
+  { label: 'My Flat Insights', href: '/my-flat-insights', noPrefetch: true },
 ];
 ---
 
@@ -29,7 +32,7 @@ const links = [
     </button>
     <nav class="nav-links" id="nav-links">
       {links.map((l) => (
-        <a href={l.href} class={l.label === active ? 'active' : ''}>{l.label}</a>
+        <a href={l.href} class={l.label === active ? 'active' : ''} data-astro-prefetch={l.noPrefetch ? 'false' : undefined}>{l.label}</a>
       ))}
     </nav>
   </div>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -312,9 +312,18 @@ const kpis = stats
     if ((navigator as any).connection?.saveData) return;
     const idle: (cb: () => void) => void =
       (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
-    idle(() => {
+    const warm = () => idle(() => {
       import('../lib/db').then((m) => m.prefetch()).catch(() => {});
     });
+    // This link is a clientPrerender target: while the page is only being speculatively
+    // prerendered (from a hover), don't download the ~4.7 MB DuckDB wasm — a hover
+    // shouldn't pull the engine for a page never visited. Defer the warm until the
+    // prerender is activated into a real navigation.
+    if ((document as any).prerendering) {
+      document.addEventListener('prerenderingchange', warm, { once: true });
+    } else {
+      warm();
+    }
   }
 
   window.addEventListener('resize', () => {

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -318,10 +318,19 @@ import Base from '../layouts/Base.astro';
     if ((navigator as any).connection?.saveData) return;
     const idle: (cb: () => void) => void =
       (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
-    idle(() => {
+    const warm = () => idle(() => {
       _db = import('../lib/db');
       _db.then((m) => m.prefetch()).catch(() => {});
     });
+    // This link is a clientPrerender target: while the page is only being speculatively
+    // prerendered (from a hover), don't download the ~4.7 MB DuckDB wasm — a hover
+    // shouldn't pull the engine for a page never visited. Defer the warm until the
+    // prerender is activated into a real navigation.
+    if ((document as any).prerendering) {
+      document.addEventListener('prerenderingchange', warm, { once: true });
+    } else {
+      warm();
+    }
   }
 
   // semantic zoom: re-sample the scatter to the visible date window so zooming in reveals more detail


### PR DESCRIPTION
## What

Enable Astro's stable **prefetch** plus the experimental **clientPrerender** API so cross-page navigation feels instant, while keeping the heavy engines out of speculative loads.

## Changes

- **`astro.config.mjs`** — `prefetch: { prefetchAll: true, defaultStrategy: 'hover' }` + `experimental: { clientPrerender: true }`. Every internal link prefetches on hover and (where Speculation Rules are supported) upgrades to a full client-side prerender.
- **`Nav.astro`** — the two Leaflet map pages (`/town-analysis`, `/my-flat-insights`) opt out with `data-astro-prefetch="false"`, so a hover never pulls Leaflet (~150 KB) + marker-cluster for a page that may never be visited.
- **`index.astro` / `psf-trends.astro`** — these *are* prerender targets, so the idle DuckDB warm is now gated behind `document.prerendering` and deferred to the `prerenderingchange` event. This prevents a speculative prerender from downloading the ~4.7 MB DuckDB wasm before a real navigation.

## Net effect per hover

- **Market Overview / PSF Trends** → full prerender (ECharts + JSON only); DuckDB warm deferred to activation.
- **Town Analysis / My Flat Insights** → no prefetch/prerender at all.

## Verification

`npm run build` passes. Confirmed in build output: exactly the two map links carry `data-astro-prefetch="false"`, and the `prerendering` guard is present in both prerendered pages' script chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)