### PR TITLE
fix(etl): guard convert_lease against out-of-range leases

### DIFF
--- a/webapp/update/convert.py
+++ b/webapp/update/convert.py
@@ -7,12 +7,19 @@ from webapp.utils import get_project_root
 
 
 def convert_lease(x):
-    if 0 < x <= 60:
+    # Bands cover leases 1-99. Anything outside (null, 0, >99) returns None so the row
+    # drops out of the lease-band views (the frontend filters IS NOT NULL and hardcodes
+    # exactly these three bands) instead of raising UnboundLocalError and aborting the ETL.
+    if x is None:
+        result = None
+    elif 0 < x <= 60:
         result = "0-60 years"
     elif 60 < x <= 80:
         result = "61-80 years"
     elif 80 < x <= 99:
         result = "81-99 years"
+    else:
+        result = None
     return result
 
 


### PR DESCRIPTION
## Problem

`convert_lease` in `webapp/update/convert.py` had no fallback branch:

```python
def convert_lease(x):
    if 0 < x <= 60:    result = "0-60 years"
    elif 60 < x <= 80: result = "61-80 years"
    elif 80 < x <= 99: result = "81-99 years"
    return result  # UnboundLocalError if x is None / 0 / >99 / negative
```

Any remaining-lease value outside 1–99 leaves `result` unbound and raises `UnboundLocalError`, which aborts the entire `df.parquet` build in the daily ETL. It's currently masked because real leases fall in ~1–98, but it's a latent landmine.

## Fix

Add explicit handling for out-of-range values, returning `None`. Valid leases (1–99) keep their existing three bands unchanged; out-of-range rows return `None` and drop out of the lease-band views — the frontend already filters `cat_remaining_lease_years IS NOT NULL` and hardcodes exactly these three bands/colors, so this is the safe, non-visible degradation.

## Verification

Tested across edge cases — no regressions to existing band boundaries:

| input | output |
|-------|--------|
| None  | None |
| 0     | None |
| 1     | 0-60 years |
| 60    | 0-60 years |
| 61    | 61-80 years |
| 80    | 61-80 years |
| 81    | 81-99 years |
| 99    | 81-99 years |
| 100   | None |
| -5    | None |

🤖 Generated with [Claude Code](https://claude.com/claude-code)