### PR TITLE
copy(web): retitle Town Analysis hero to "Every sale, mapped."

### DIFF
--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -9,7 +9,7 @@ import Base from '../layouts/Base.astro';
   <section class="hero">
     <div class="wrap">
       <span class="eyebrow rise"><span class="dot"></span> Explore by Town</span>
-      <h1 class="title rise" style="animation-delay:.05s">Where the value<br /><em>hides</em>.</h1>
+      <h1 class="title rise" style="animation-delay:.05s">Every sale, <em>mapped</em>.</h1>
       <p class="lede solo rise" style="animation-delay:.1s">
         Map every recent transaction in a town, banded low / mid / high against its own median.
       </p>


### PR DESCRIPTION
## What

Changes the Town Analysis hero title from the two-line **"Where the value hides."** to a single-line **"Every sale, mapped."**

## Why

- Names what the page actually does — the pin map of every recent transaction is the hero element.
- Drops the `<br />` split in favour of a single line.
- Avoids thematic overlap with the psf-trends "street by street" title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)