### PR TITLE
feat(web): Record sales leaderboard for Town Analysis

### DIFF
--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -48,12 +48,13 @@ import Base from '../layouts/Base.astro';
       </div>
     </div>
 
-    <!-- 02 · TOP SALE PER TOWN -->
-    <div class="sec-head"><span class="num">02</span><h2>Top sale in each town</h2>
-      <span class="hint">Highest resale price recorded per town for the selected flat type, vs the cross-town median.</span></div>
+    <!-- 02 · RECORD SALES -->
+    <div class="sec-head"><span class="num">02</span><h2>Record sales</h2>
+      <span class="hint">The single highest price on record per town for the selected flat type. These are outliers — big units, high floors, prime blocks — shown with context, not typical prices.</span></div>
     <div class="card chart-card">
-      <div class="chart-head"><div class="chart-title" id="highest-title">Highest recorded resale price by town</div></div>
-      <div id="chart-highest" style="width:100%;height:460px"></div>
+      <div class="chart-head"><div class="chart-title" id="record-title">Most expensive on record</div>
+        <div class="chart-sub">Ranked by peak transaction · town median shown for scale</div></div>
+      <div class="lead" id="record-list"></div>
     </div>
 
     <!-- 03 · DATA TABLE -->
@@ -77,6 +78,22 @@ import Base from '../layouts/Base.astro';
   .cat-line .bar{flex:1;height:8px;border-radius:999px;background:#efeadf;overflow:hidden}
   .cat-line .bar span{display:block;height:100%;width:0}
   .cat-line .amt{width:52px;text-align:right;font-family:var(--font-mono);font-size:12.5px;color:var(--ink-2)}
+  /* record sales leaderboard (section 02). Rows are injected via innerHTML, so the
+     .rec rules are :global — Astro's scoping only tags elements present in the template. */
+  .chart-sub{font-size:12.5px;color:var(--ink-3);margin-top:3px}
+  .lead{display:grid;gap:10px;margin-top:16px}
+  :global(.rec){display:grid;grid-template-columns:26px 150px 1fr auto;align-items:center;gap:14px;
+    border:1px solid var(--line);border-radius:12px;background:var(--paper);padding:12px 16px}
+  :global(.rec .rank){font-family:var(--font-mono);font-size:13px;font-weight:600;color:var(--red-ink)}
+  :global(.rec .town){font-weight:600;font-size:14.5px}
+  :global(.rec .ctx){font-size:12.5px;color:var(--ink-3);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  :global(.rec .price){font-family:var(--font-mono);font-weight:600;font-size:16px;letter-spacing:-.01em;text-align:right;white-space:nowrap}
+  :global(.rec .price small){display:block;font-family:var(--font-sans);font-weight:400;font-size:11px;color:var(--ink-3);letter-spacing:0}
+  :global(.rec.hero){background:linear-gradient(180deg,var(--paper-2),var(--red-wash))}
+  @media (max-width:640px){
+    :global(.rec){grid-template-columns:22px 1fr auto;row-gap:4px}
+    :global(.rec .ctx){grid-column:2 / -1;white-space:normal}
+  }
   /* Leaflet hover tooltip on-brand */
   :global(.leaflet-container){font-family:var(--font-sans);background:#f3ede1}
   :global(.leaflet-tooltip.hdb-tip){
@@ -94,7 +111,6 @@ import Base from '../layouts/Base.astro';
   import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
   import L from 'leaflet';
   import 'leaflet.markercluster';
-  import echarts from '../lib/echarts';
   // DuckDB-WASM is heavy and NOT needed for first paint: the default view renders from
   // a precomputed snapshot (town-analysis.json). The engine is imported lazily and only
   // booted when the visitor changes a filter (warmed on idle so that first change is
@@ -104,7 +120,6 @@ import Base from '../layouts/Base.astro';
     if (!_db) _db = import('../lib/db');
     return (await _db).query<T>(sql);
   };
-  import { baseOption, palette, axisLabel, splitLine, axisLine, ink3, ink, mono } from '../lib/echartsTheme';
   import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
 
   const DEFAULT_TOWN = 'ANG MO KIO';
@@ -114,7 +129,7 @@ import Base from '../layouts/Base.astro';
   const sql = (s: string) => s.replace(/'/g, "''");
 
   type Row = { lat: number; lng: number; price: number; address: string; month: string; storey: string; psf: number; lease: number; band?: string };
-  type Hi = { town: string; mx: number };
+  type Rec = { town: string; price: number; address: string; storey: string; area: number; month: string; med: number };
   let currentRows: Row[] = [];
   let currentTown = DEFAULT_TOWN;
   let currentFlat = DEFAULT_FLAT;
@@ -220,37 +235,42 @@ import Base from '../layouts/Base.astro';
     setStreets(streets.map((s) => s.street_name));
   }
 
-  // ---- highest sale per town ----
-  const highestChart = echarts.init($('chart-highest'));
-  function paintHighest(input: Hi[]) {
-    const med = median(input.map((r) => r.mx));
-    const rows = [...input].reverse(); // ECharts horizontal bar draws bottom-up
-    highestChart.setOption({
-      ...baseOption(),
-      grid: { left: 120, right: 70, top: 12, bottom: 30, containLabel: false },
-      tooltip: { trigger: 'item', valueFormatter: (v: number) => money(v) },
-      xAxis: { type: 'value', axisLabel: { ...axisLabel, formatter: (v: number) => moneyShort(v) }, splitLine },
-      yAxis: { type: 'category', data: rows.map((r) => titleCase(r.town)), axisLabel: { color: '#5b544a', fontSize: 12 }, axisLine, axisTick: { show: false } },
-      series: [{
-        type: 'bar', barWidth: 16,
-        itemStyle: { color: (p: any) => (rows[p.dataIndex].mx >= med ? palette[0] : palette[5]), borderRadius: 4 },
-        label: { show: true, position: 'right', formatter: (p: any) => moneyShort(p.value), color: ink3, fontFamily: mono, fontSize: 11 },
-        markLine: {
-          symbol: 'none', silent: true,
-          lineStyle: { color: ink3, type: 'dashed' },
-          data: [{ xAxis: med }],
-          label: { formatter: `median ${moneyShort(med)}`, color: ink3, fontSize: 11 },
-        },
-        data: rows.map((r) => r.mx),
-      }],
-    });
+  // ---- record sale per town ----
+  // Each town's single highest sale on record for the selected flat, with the flat's
+  // context (address, storey, area, month) and the town median beside it so the
+  // outlier reads as a headline rather than a typical price.
+  function paintRecords(input: Rec[]) {
+    const flat = titleCase(($('sel-flat') as HTMLSelectElement).value);
+    $('record-title').textContent = `Most expensive ${flat} on record`;
+    $('record-list').innerHTML = input.map((r, i) => `
+      <div class="rec${i === 0 ? ' hero' : ''}">
+        <span class="rank">${i + 1}</span>
+        <span class="town">${titleCase(r.town)}</span>
+        <span class="ctx">${titleCase(r.address)} · storey ${r.storey.toLowerCase()} · ${Math.round(r.area)} sqm · sold ${r.month}</span>
+        <span class="price">${moneyShort(r.price)}<small>town median ${moneyShort(r.med)}</small></span>
+      </div>`).join('');
   }
-  async function loadHighest() {
+  async function loadRecords() {
     const flat = ($('sel-flat') as HTMLSelectElement).value;
-    const rows = await query<Hi>(
-      `SELECT town, max(resale_price) mx FROM resale WHERE flat_type='${sql(flat)}' GROUP BY town ORDER BY mx DESC LIMIT 15`,
-    ).then((rs) => rs.map((r) => ({ town: r.town, mx: Number(r.mx) })));
-    paintHighest(rows);
+    const rows = await query<Rec>(
+      `WITH scoped AS (
+         SELECT town, resale_price, address, storey_range, floor_area_sqm, month
+         FROM resale WHERE flat_type='${sql(flat)}'
+       ), med AS (
+         SELECT town, median(resale_price) med FROM scoped GROUP BY town
+       ), ranked AS (
+         SELECT *, row_number() OVER (PARTITION BY town ORDER BY resale_price DESC, month DESC) rn
+         FROM scoped
+       )
+       SELECT r.town, r.resale_price price, r.address, r.storey_range storey,
+              r.floor_area_sqm area, r.month, m.med
+       FROM ranked r JOIN med m USING (town)
+       WHERE r.rn = 1 ORDER BY price DESC LIMIT 12`,
+    ).then((rs) => rs.map((r) => ({
+      town: r.town, price: Number(r.price), address: r.address,
+      storey: r.storey, area: Number(r.area), month: r.month, med: Number(r.med),
+    })));
+    paintRecords(rows);
   }
 
   // ---- CSV download ----
@@ -265,7 +285,7 @@ import Base from '../layouts/Base.astro';
   });
 
   // ---- boot: paint the default view from the precomputed snapshot, then wire filters ----
-  type Snapshot = { default: { town: string; flat: string }; towns: string[]; flatTypes: string[]; streets: string[]; rows: Row[]; highest: Hi[] };
+  type Snapshot = { default: { town: string; flat: string }; towns: string[]; flatTypes: string[]; streets: string[]; rows: Row[]; records: Rec[] };
   (async () => {
     const data: Snapshot = await fetch(`${import.meta.env.BASE_URL}data/town-analysis.json`).then((r) => {
       if (!r.ok) throw new Error(`town-analysis.json ${r.status}`);
@@ -277,7 +297,7 @@ import Base from '../layouts/Base.astro';
 
     // Paint immediately from JSON — no DuckDB needed for the default view.
     paintMap(data.rows, data.default.town, data.default.flat);
-    paintHighest(data.highest);
+    paintRecords(data.records);
 
     // Filters go through DuckDB. Threshold-only changes just re-band the rows we
     // already have, so they never touch the engine. Changing town reloads its street
@@ -285,7 +305,7 @@ import Base from '../layouts/Base.astro';
     $('sel-town').addEventListener('change', async () => { await loadStreets(); loadMap(); });
     $('sel-street').addEventListener('change', loadMap);
     $('sel-thr').addEventListener('change', () => paintMap(currentRows, currentTown, currentFlat));
-    $('sel-flat').addEventListener('change', () => { loadMap(); loadHighest(); });
+    $('sel-flat').addEventListener('change', () => { loadMap(); loadRecords(); });
 
     warmEngineWhenIdle();
   })();
@@ -302,5 +322,5 @@ import Base from '../layouts/Base.astro';
     });
   }
 
-  window.addEventListener('resize', () => { highestChart.resize(); map.invalidateSize(); });
+  window.addEventListener('resize', () => { map.invalidateSize(); });
 </script>

--- a/webapp/update/emit_web.py
+++ b/webapp/update/emit_web.py
@@ -266,14 +266,27 @@ def emit_town_analysis(df: pl.DataFrame) -> None:
         .to_dicts()
     )
 
-    # Highest sale per town for the default flat — mirrors renderHighest()'s query.
-    highest = (
-        df.filter(pl.col("flat_type") == TA_DEFAULT_FLAT)
-        .group_by("town")
-        .agg(pl.col("resale_price").max().alias("mx"))
-        .sort("mx", descending=True)
-        .head(15)
-        .select(["town", "mx"])
+    # Record sale per town for the default flat — mirrors loadRecords()'s query: the
+    # single highest sale per town, with its flat's context and the town median.
+    scoped = df.filter(pl.col("flat_type") == TA_DEFAULT_FLAT)
+    town_med = scoped.group_by("town").agg(pl.col("resale_price").median().alias("med"))
+    records = (
+        # Sort price-desc then take the first (=max) row per town, keeping its columns aligned.
+        scoped.sort(["resale_price", "month"], descending=[True, True])
+        .group_by("town", maintain_order=True)
+        .agg(pl.exclude("town").first())
+        .join(town_med, on="town")
+        .sort("resale_price", descending=True)
+        .head(12)
+        .select(
+            "town",
+            pl.col("resale_price").alias("price"),
+            "address",
+            pl.col("storey_range").alias("storey"),
+            pl.col("floor_area_sqm").alias("area"),
+            "month",
+            "med",
+        )
         .to_dicts()
     )
 
@@ -289,7 +302,7 @@ def emit_town_analysis(df: pl.DataFrame) -> None:
         "flatTypes": sorted(df["flat_type"].unique().to_list()),
         "streets": streets,
         "rows": rows,
-        "highest": highest,
+        "records": records,
     }
     out = OUT_DIR / "town-analysis.json"
     out.write_text(json.dumps(payload))


### PR DESCRIPTION
## What

Replaces section 02 of Town Analysis ("Top sale in each town") with a **Record sales** leaderboard.

The old panel was a single `max(resale_price)` bar per town — by definition one transaction, almost always an outlier (a jumbo unit, top floor, or prime block), and it answered no real buyer question while reading like analysis.

The new panel keeps the shareable "most expensive on record" hook but frames it honestly: each town's top sale is shown with its flat's context (address, storey, floor area, month sold) and the **town median right beside it**, so the outlier reads as a headline, not a typical price.

## Changes

- `web/src/pages/town-analysis.astro` — swap the ECharts horizontal bar chart for a card leaderboard (rank / town / context / price + town median). Drop the now-unused `echarts` + `echartsTheme` imports. `.rec` styles use `:global()` since rows are injected via `innerHTML` (same pattern the file already uses for Leaflet tooltips).
- `webapp/update/emit_web.py` — snapshot generator emits `records` (top sale per town joined to its flat details + town median) instead of `highest`, so the default view still paints without booting DuckDB.

## Verify

- `astro build` passes; town-analysis bundle no longer pulls in ECharts.
- Rendered preview confirms styled cards, hero gradient on #1, and dynamic title ("Most expensive 4 Room on record").
- The outlier story shows through — e.g. Bukit Merah's record is a 150 sqm ground-floor unit at \$1.53m vs a \$760k town median.

Note: the snapshot JSONs are gitignored build artifacts (regenerated in CI), so only the `emit_web.py` change is tracked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)