### PR TITLE
test(web): run E2E across chromium, firefox, and webkit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,9 +73,9 @@ jobs:
           fi
           echo "Vendored fonts match fonts.spec.mjs."
 
-      - name: Install Playwright browser
+      - name: Install Playwright browsers
         working-directory: web
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install --with-deps chromium firefox webkit
 
       - name: Run E2E tests
         working-directory: web

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
     baseURL: `http://localhost:${PORT}`,
     trace: 'on-first-retry',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
   webServer: {
     command: `bun run build && bunx wrangler dev --port ${PORT} --ip 127.0.0.1`,
     url: `http://localhost:${PORT}`,


### PR DESCRIPTION
## What
E2E tests previously ran on Chromium only. This adds Firefox and WebKit Playwright projects and installs all three browsers in CI, so the DuckDB-WASM app is exercised on all major engines — WebKit/Safari in particular being the notable prior gap.

## Changes
- `web/playwright.config.ts` — add `firefox` and `webkit` projects alongside `chromium`.
- `.github/workflows/test.yaml` — `playwright install --with-deps chromium firefox webkit`.

## Verification
Ran the full suite locally across all three browsers: Firefox and WebKit behave identically to Chromium (same specs pass, same pre-existing local-data failures on all three — no browser-specific breakage). WebKit boots DuckDB-WASM fine (cross-origin isolation OK).

## Cost
Public repo, so no Actions minute cost. Playwright runs `fullyParallel`, so wall-clock stays well under 3× (full 3-browser run ~4 min locally, dominated by the shared build + wrangler startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)