### PR TITLE
ci: add web/ pre-commit hooks mirroring validate.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,28 @@ repos:
       - id: ruff
         entry: ruff check
         args: [ --fix ]
+
+  # web/ (Astro site) — mirrors the checks in .github/workflows/validate.yaml.
+  # pre-commit has no per-hook cwd, so each entry cds into web/ and runs the
+  # matching bun script. pass_filenames is false because these tools glob the
+  # whole project themselves (as they do in CI).
+  - repo: local
+    hooks:
+      - id: web-astro-check
+        name: astro check (web)
+        entry: bash -c 'cd web && bun run check'
+        language: system
+        files: ^web/
+        pass_filenames: false
+      - id: web-eslint
+        name: eslint (web)
+        entry: bash -c 'cd web && bun run lint'
+        language: system
+        files: ^web/
+        pass_filenames: false
+      - id: web-prettier
+        name: prettier (web)
+        entry: bash -c 'cd web && bun run format:check'
+        language: system
+        files: ^web/
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Adds pre-commit hooks for the Astro site (`web/`) that mirror the static checks enforced by CI in `.github/workflows/validate.yaml`. Previously `.pre-commit-config.yaml` only covered Python (black/isort/ruff) — which no workflow enforces — while the actual CI lint gate (`web/`) had no local pre-commit coverage.

## Changes

Three new `local` hooks, scoped to `files: ^web/` and run via `bun`:

| Hook | Command | CI equivalent |
|------|---------|---------------|
| `web-astro-check` | `bun run check` (`astro check`) | Type-check step |
| `web-eslint` | `bun run lint` (`eslint .`) | Lint step |
| `web-prettier` | `bun run format:check` (`prettier --check .`) | Formatting step |

Each hook `cd`s into `web/` (pre-commit has no per-hook cwd) and uses `pass_filenames: false` since the tools glob the project themselves, matching CI behavior.

## Notes

- The hooks require `web/` dependencies to be installed (`bun install`); the same prerequisite CI satisfies before running these checks.
- Existing Python hooks are unchanged.

## Testing

Ran all three hooks with `pre-commit run <hook> --all-files` after `bun install` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)