### PR TITLE
refactor(web): extract reusable Astro components from duplicated markup

### DIFF
--- a/web/src/components/ChartCard.astro
+++ b/web/src/components/ChartCard.astro
@@ -1,0 +1,21 @@
+---
+// Card + heading shell shared by every chart / leaderboard panel. The title is a prop
+// (scripts rewrite it via `titleId`); anything that sits beside it in the head — a pill,
+// note or sub-line — goes in the `head` slot, and the body (chart box, table, list…)
+// is the default slot.
+interface Props {
+  title: string;
+  titleId?: string;
+  class?: string;
+  style?: string;
+}
+const { title, titleId, class: className, style } = Astro.props;
+---
+
+<div class:list={['card', 'chart-card', className]} style={style}>
+  <div class="chart-head">
+    <div class="chart-title" id={titleId}>{title}</div>
+    <slot name="head" />
+  </div>
+  <slot />
+</div>

--- a/web/src/components/DataTable.astro
+++ b/web/src/components/DataTable.astro
@@ -1,0 +1,28 @@
+---
+// The <table class="comp"> shell shared by every data table: a header row plus a
+// single full-width placeholder row the page script replaces once data loads. The
+// surrounding card and footer vary per page, so they stay in the page.
+interface Header {
+  label: string;
+  align?: 'r';
+}
+interface Props {
+  headers: Header[];
+  bodyId: string;
+  loadingText?: string;
+}
+const { headers, bodyId, loadingText = 'Loading…' } = Astro.props;
+---
+
+<table class="comp">
+  <thead>
+    <tr>
+      {headers.map((h) => <th class={h.align}>{h.label}</th>)}
+    </tr>
+  </thead>
+  <tbody id={bodyId}>
+    <tr>
+      <td colspan={headers.length} style="padding:22px 16px;color:var(--ink-3)">{loadingText}</td>
+    </tr>
+  </tbody>
+</table>

--- a/web/src/components/FieldSelect.astro
+++ b/web/src/components/FieldSelect.astro
@@ -1,0 +1,11 @@
+---
+// Labelled native <select> for the filter bars. Options are usually populated by the
+// page script (empty slot), but static ones can be passed as the default slot.
+interface Props {
+  label: string;
+  id: string;
+}
+const { label, id } = Astro.props;
+---
+
+<span class="field-select"><span class="lab">{label}</span><select id={id}><slot /></select></span>

--- a/web/src/components/LeafletMap.astro
+++ b/web/src/components/LeafletMap.astro
@@ -1,0 +1,51 @@
+---
+// Leaflet map container. Renders the sized box the page script mounts a map into
+// (`L.map(id)`), and owns the on-brand container + tooltip styling that was previously
+// duplicated across the two map pages. The `.hdb-tip` / `.leaflet-*` overrides are
+// :global because Leaflet builds those elements at runtime. Height is per-page: Town
+// Analysis fixes it, My Flat Insights uses a min-height.
+interface Props {
+  id: string;
+  height?: string;
+  minHeight?: string;
+}
+const { id, height, minHeight } = Astro.props;
+const style = [height && `height:${height}`, minHeight && `min-height:${minHeight}`]
+  .filter(Boolean)
+  .join(';');
+---
+
+<div id={id} class="map-real" style={style || undefined}></div>
+
+<style>
+  .map-real {
+    border-radius: var(--radius);
+    border: 1px solid var(--line);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    z-index: 0;
+  }
+  /* Leaflet builds these elements at runtime, so they must be :global. */
+  :global(.leaflet-container) {
+    font-family: var(--font-sans);
+    background: #f3ede1;
+  }
+  :global(.leaflet-tooltip.hdb-tip) {
+    background: var(--paper-2);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    box-shadow: var(--shadow);
+    color: var(--ink);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    padding: 9px 12px;
+    line-height: 1.5;
+    white-space: nowrap;
+  }
+  :global(.leaflet-tooltip.hdb-tip b) {
+    font-weight: 600;
+  }
+  :global(.leaflet-tooltip-top.hdb-tip::before) {
+    border-top-color: var(--paper-2);
+  }
+</style>

--- a/web/src/components/Pager.astro
+++ b/web/src/components/Pager.astro
@@ -1,0 +1,14 @@
+---
+// Prev / Next pager buttons. Both start disabled; the page script toggles them by id
+// as it pages through results. Styling lives in global.css (.pager).
+interface Props {
+  prevId?: string;
+  nextId?: string;
+}
+const { prevId = 'rec-prev', nextId = 'rec-next' } = Astro.props;
+---
+
+<span class="pager">
+  <button class="ghost pg" id={prevId} disabled>← Prev</button>
+  <button class="ghost pg" id={nextId} disabled>Next →</button>
+</span>

--- a/web/src/components/SecHead.astro
+++ b/web/src/components/SecHead.astro
@@ -1,0 +1,17 @@
+---
+// Numbered section header: a mono number in the gutter, a Fraunces heading, and an
+// optional deck (the ".hint") beneath it. The deck text is passed as the default slot;
+// `hintId` exposes it for scripts that rewrite the copy (e.g. My Flat Insights).
+interface Props {
+  num: string;
+  title: string;
+  rise?: boolean;
+  hintId?: string;
+}
+const { num, title, rise = false, hintId } = Astro.props;
+---
+
+<div class:list={['sec-head', { rise }]}>
+  <span class="num">{num}</span><h2>{title}</h2>
+  <span class="hint" id={hintId}><slot /></span>
+</div>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
+import FieldSelect from '../components/FieldSelect.astro';
 import { trendsSVG } from '../lib/echartsSSR';
 import { moneyShort, psf as fpsf } from '../lib/format';
 import fs from 'node:fs';
@@ -149,10 +150,8 @@ const kpis = stats
       months.
     </SecHead>
     <div class="controls" style="margin-bottom:16px">
-      <span class="field-select"><span class="lab">Town</span><select id="rec-town"></select></span>
-      <span class="field-select"
-        ><span class="lab">Flat type</span><select id="rec-flat"></select></span
-      >
+      <FieldSelect label="Town" id="rec-town" />
+      <FieldSelect label="Flat type" id="rec-flat" />
     </div>
     <div class="card table-card">
       <table class="comp">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,6 +4,7 @@ import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
 import FieldSelect from '../components/FieldSelect.astro';
 import Pager from '../components/Pager.astro';
+import DataTable from '../components/DataTable.astro';
 import { trendsSVG } from '../lib/echartsSSR';
 import { moneyShort, psf as fpsf } from '../lib/format';
 import fs from 'node:fs';
@@ -155,20 +156,19 @@ const kpis = stats
       <FieldSelect label="Flat type" id="rec-flat" />
     </div>
     <div class="card table-card">
-      <table class="comp">
-        <thead
-          ><tr>
-            <th>Sold</th><th>Town</th><th>Address</th><th>Type</th>
-            <th class="r">Area (sqft)</th><th class="r">Price</th><th class="r">PSF</th>
-          </tr></thead
-        >
-        <tbody id="tbody-recent">
-          <tr
-            ><td colspan="7" style="padding:22px 16px;color:var(--ink-3)">Loading market data…</td
-            ></tr
-          >
-        </tbody>
-      </table>
+      <DataTable
+        headers={[
+          { label: 'Sold' },
+          { label: 'Town' },
+          { label: 'Address' },
+          { label: 'Type' },
+          { label: 'Area (sqft)', align: 'r' },
+          { label: 'Price', align: 'r' },
+          { label: 'PSF', align: 'r' },
+        ]}
+        bodyId="tbody-recent"
+        loadingText="Loading market data…"
+      />
       <div class="tbl-foot">
         <span id="recent-foot">&nbsp;</span>
         <Pager />

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SecHead from '../components/SecHead.astro';
 import { trendsSVG } from '../lib/echartsSSR';
 import { moneyShort, psf as fpsf } from '../lib/format';
 import fs from 'node:fs';
@@ -91,12 +92,9 @@ const kpis = stats
 
   <main class="wrap pagepad">
     <!-- 01 · PRICE TRENDS -->
-    <div class="sec-head rise">
-      <span class="num">01</span><h2>Price trends</h2>
-      <span class="hint"
-        >Median resale price over time. Switch the lens to compare by lease band, town or flat type.</span
-      >
-    </div>
+    <SecHead num="01" title="Price trends" rise>
+      Median resale price over time. Switch the lens to compare by lease band, town or flat type.
+    </SecHead>
     <div class="controls" style="margin-bottom:16px">
       <div class="chipset" id="trend-toggle">
         <button class="chip on" data-mode="lease">Lease band</button>
@@ -112,13 +110,10 @@ const kpis = stats
     </div>
 
     <!-- 02 · PRICE MAP -->
-    <div class="sec-head">
-      <span class="num">02</span><h2>Price map</h2>
-      <span class="hint"
-        >Median 4-room resale price, last 12 months — darker means pricier. Switch to subzones for a
-        finer view; areas with fewer than 10 sales are left blank.</span
-      >
-    </div>
+    <SecHead num="02" title="Price map">
+      Median 4-room resale price, last 12 months — darker means pricier. Switch to subzones for a
+      finer view; areas with fewer than 10 sales are left blank.
+    </SecHead>
     <div class="controls" style="margin-bottom:16px">
       <div class="chipset" id="map-toggle">
         <button class="chip on" data-level="town">By town</button>
@@ -133,22 +128,18 @@ const kpis = stats
     </div>
 
     <!-- 03 · DISTRIBUTION -->
-    <div class="sec-head">
-      <span class="num">03</span><h2>Price distribution by town</h2>
-      <span class="hint"
-        >Spread of 4-room resale prices, last 12 months — box shows the middle 50%.</span
-      >
-    </div>
+    <SecHead num="03" title="Price distribution by town">
+      Spread of 4-room resale prices, last 12 months — box shows the middle 50%.
+    </SecHead>
     <div class="card chart-card">
       <div class="chart-head"><div class="chart-title">Resale price spread · 4-room</div></div>
       <div id="chart-box" class="chart-box"></div>
     </div>
 
     <!-- 04 · LEASE RELATIONSHIP -->
-    <div class="sec-head">
-      <span class="num">04</span><h2>Price &amp; remaining lease</h2>
-      <span class="hint">How 4-room resale price relates to years left on the lease.</span>
-    </div>
+    <SecHead num="04" title="Price & remaining lease">
+      How 4-room resale price relates to years left on the lease.
+    </SecHead>
     <div class="split" style="grid-template-columns:1.5fr 1fr">
       <div class="card chart-card">
         <div class="chart-head"><div class="chart-title">Resale price vs remaining lease</div></div>
@@ -161,13 +152,10 @@ const kpis = stats
     </div>
 
     <!-- 05 · RECENT TRANSACTIONS -->
-    <div class="sec-head">
-      <span class="num">05</span><h2>Recent transactions</h2>
-      <span class="hint"
-        >Latest registered resale deals. Filter by town or flat type and page through the last 12
-        months.</span
-      >
-    </div>
+    <SecHead num="05" title="Recent transactions">
+      Latest registered resale deals. Filter by town or flat type and page through the last 12
+      months.
+    </SecHead>
     <div class="controls" style="margin-bottom:16px">
       <span class="field-select"><span class="lab">Town</span><select id="rec-town"></select></span>
       <span class="field-select"

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -3,6 +3,7 @@ import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
 import FieldSelect from '../components/FieldSelect.astro';
+import Pager from '../components/Pager.astro';
 import { trendsSVG } from '../lib/echartsSSR';
 import { moneyShort, psf as fpsf } from '../lib/format';
 import fs from 'node:fs';
@@ -170,10 +171,7 @@ const kpis = stats
       </table>
       <div class="tbl-foot">
         <span id="recent-foot">&nbsp;</span>
-        <span class="pager">
-          <button class="ghost pg" id="rec-prev" disabled>← Prev</button>
-          <button class="ghost pg" id="rec-next" disabled>Next →</button>
-        </span>
+        <Pager />
       </div>
     </div>
   </main>
@@ -204,20 +202,6 @@ const kpis = stats
     .map-box {
       height: 300px;
     }
-  }
-  /* Recent-transactions pager: compact ghost buttons anchored to the footer's right. */
-  .pager {
-    display: inline-flex;
-    gap: 8px;
-  }
-  .pager .pg {
-    padding: 7px 13px;
-    font-size: 13px;
-  }
-  .pager .pg:disabled {
-    opacity: 0.4;
-    cursor: default;
-    border-color: var(--line);
   }
 </style>
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
+import ChartCard from '../components/ChartCard.astro';
 import { trendsSVG } from '../lib/echartsSSR';
 import { moneyShort, psf as fpsf } from '../lib/format';
 import fs from 'node:fs';
@@ -102,12 +103,9 @@ const kpis = stats
         <button class="chip" data-mode="town">Town</button>
       </div>
     </div>
-    <div class="card chart-card">
-      <div class="chart-head">
-        <div class="chart-title" id="trend-title">Median resale price by lease band</div>
-      </div>
+    <ChartCard title="Median resale price by lease band" titleId="trend-title">
       <div id="chart-trends" class="chart-box" set:html={heroSVG} />
-    </div>
+    </ChartCard>
 
     <!-- 02 · PRICE MAP -->
     <SecHead num="02" title="Price map">
@@ -120,35 +118,29 @@ const kpis = stats
         <button class="chip" data-level="subzone">By subzone</button>
       </div>
     </div>
-    <div class="card chart-card">
-      <div class="chart-head">
-        <div class="chart-title" id="map-title">Median resale price · 4-room · by town</div>
-      </div>
+    <ChartCard title="Median resale price · 4-room · by town" titleId="map-title">
       <div id="chart-map" class="chart-box map-box"></div>
-    </div>
+    </ChartCard>
 
     <!-- 03 · DISTRIBUTION -->
     <SecHead num="03" title="Price distribution by town">
       Spread of 4-room resale prices, last 12 months — box shows the middle 50%.
     </SecHead>
-    <div class="card chart-card">
-      <div class="chart-head"><div class="chart-title">Resale price spread · 4-room</div></div>
+    <ChartCard title="Resale price spread · 4-room">
       <div id="chart-box" class="chart-box"></div>
-    </div>
+    </ChartCard>
 
     <!-- 04 · LEASE RELATIONSHIP -->
     <SecHead num="04" title="Price & remaining lease">
       How 4-room resale price relates to years left on the lease.
     </SecHead>
     <div class="split" style="grid-template-columns:1.5fr 1fr">
-      <div class="card chart-card">
-        <div class="chart-head"><div class="chart-title">Resale price vs remaining lease</div></div>
+      <ChartCard title="Resale price vs remaining lease">
         <div id="chart-scatter" class="chart-box"></div>
-      </div>
-      <div class="card chart-card">
-        <div class="chart-head"><div class="chart-title">Transactions by lease band</div></div>
+      </ChartCard>
+      <ChartCard title="Transactions by lease band">
         <div id="chart-buckets" class="chart-box"></div>
-      </div>
+      </ChartCard>
     </div>
 
     <!-- 05 · RECENT TRANSACTIONS -->

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -3,6 +3,7 @@ import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
 import DataTable from '../components/DataTable.astro';
+import LeafletMap from '../components/LeafletMap.astro';
 ---
 
 <Base active="My Flat Insights" title="My Flat Insights | HDB Kaki">
@@ -279,7 +280,7 @@ import DataTable from '../components/DataTable.astro';
           />
           <div class="comp-foot"><span id="comp-foot">&nbsp;</span></div>
         </div>
-        <div id="ins-map" class="map-real"></div>
+        <LeafletMap id="ins-map" minHeight="340px" />
       </div>
     </div>
   </section>
@@ -838,37 +839,6 @@ import DataTable from '../components/DataTable.astro';
   .lease-flag.warn {
     border-color: var(--red);
     background: var(--red-wash);
-  }
-  /* leaflet map */
-  .map-real {
-    min-height: 340px;
-    border-radius: var(--radius);
-    border: 1px solid var(--line);
-    box-shadow: var(--shadow);
-    overflow: hidden;
-    z-index: 0;
-  }
-  :global(.leaflet-container) {
-    font-family: var(--font-sans);
-    background: #f3ede1;
-  }
-  :global(.leaflet-tooltip.hdb-tip) {
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    box-shadow: var(--shadow);
-    color: var(--ink);
-    font-family: var(--font-sans);
-    font-size: 13px;
-    padding: 9px 12px;
-    line-height: 1.5;
-    white-space: nowrap;
-  }
-  :global(.leaflet-tooltip.hdb-tip b) {
-    font-weight: 600;
-  }
-  :global(.leaflet-tooltip-top.hdb-tip::before) {
-    border-top-color: var(--paper-2);
   }
   @media (max-width: 900px) {
     .form-grid {

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
+import ChartCard from '../components/ChartCard.astro';
 ---
 
 <Base active="My Flat Insights" title="My Flat Insights | HDB Kaki">
@@ -124,13 +125,10 @@ import SecHead from '../components/SecHead.astro';
       </SecHead>
 
       <div class="split" style="grid-template-columns:1.55fr 1fr">
-        <div class="card chart-card">
-          <div class="chart-head">
-            <div class="chart-title" id="traj-title">Median PSF over time</div>
-            <span class="pill" id="traj-pill">—</span>
-          </div>
+        <ChartCard title="Median PSF over time" titleId="traj-title">
+          <span class="pill" id="traj-pill" slot="head">—</span>
           <div id="traj-chart" style="width:100%;height:300px"></div>
-        </div>
+        </ChartCard>
         <div class="card returns">
           <div class="ret-head">Your return so far</div>
           <p class="ret-lede">
@@ -190,14 +188,11 @@ import SecHead from '../components/SecHead.astro';
       </div>
 
       <div class="split" style="grid-template-columns:1.4fr 1fr;margin-top:18px">
-        <div class="card chart-card">
-          <div class="chart-head">
-            <div class="chart-title">Where you sit in the market</div>
-            <span class="pill" id="pctile-pill">—</span>
-          </div>
+        <ChartCard title="Where you sit in the market">
+          <span class="pill" id="pctile-pill" slot="head">—</span>
           <div id="dist-chart" style="width:100%;height:210px"></div>
           <div class="dist-cap" id="dist-cap">&nbsp;</div>
-        </div>
+        </ChartCard>
         <div class="market-tiles">
           <div class="card mt">
             <div class="mt-k">Sales this window</div><div class="mt-v" id="mt-vel">—</div><div
@@ -250,15 +245,16 @@ import SecHead from '../components/SecHead.astro';
         <div class="lease-flags" id="lease-flags"></div>
       </div>
 
-      <div class="card chart-card" style="margin-top:18px">
-        <div class="chart-head">
-          <div class="chart-title" id="leasecurve-title">Median PSF by remaining lease</div>
-          <span class="chart-sub" id="leasecurve-sub"
-            >Same flat type, island-wide, last 24 months</span
-          >
-        </div>
+      <ChartCard
+        title="Median PSF by remaining lease"
+        titleId="leasecurve-title"
+        style="margin-top:18px"
+      >
+        <span class="chart-sub" id="leasecurve-sub" slot="head"
+          >Same flat type, island-wide, last 24 months</span
+        >
         <div id="lease-chart" style="width:100%;height:260px"></div>
-      </div>
+      </ChartCard>
 
       <!-- 05 COMPARABLES -->
       <SecHead num="05" title="Nearby comparables" hintId="comp-hint">

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
+import DataTable from '../components/DataTable.astro';
 ---
 
 <Base active="My Flat Insights" title="My Flat Insights | HDB Kaki">
@@ -263,22 +264,19 @@ import ChartCard from '../components/ChartCard.astro';
 
       <div class="split">
         <div class="card comp-wrap">
-          <table class="comp">
-            <thead
-              ><tr
-                ><th>Address</th><th>Storey</th><th class="r">Area</th><th class="r">Lease</th><th
-                  class="r">Price</th
-                ><th class="r">PSF</th><th class="r">Sold</th></tr
-              ></thead
-            >
-            <tbody id="comp-body"
-              ><tr
-                ><td colspan="7" style="padding:22px 16px;color:var(--ink-3)"
-                  >Enter a postal code…</td
-                ></tr
-              ></tbody
-            >
-          </table>
+          <DataTable
+            headers={[
+              { label: 'Address' },
+              { label: 'Storey' },
+              { label: 'Area', align: 'r' },
+              { label: 'Lease', align: 'r' },
+              { label: 'Price', align: 'r' },
+              { label: 'PSF', align: 'r' },
+              { label: 'Sold', align: 'r' },
+            ]}
+            bodyId="comp-body"
+            loadingText="Enter a postal code…"
+          />
           <div class="comp-foot"><span id="comp-foot">&nbsp;</span></div>
         </div>
         <div id="ins-map" class="map-real"></div>

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SecHead from '../components/SecHead.astro';
 ---
 
 <Base active="My Flat Insights" title="My Flat Insights | HDB Kaki">
@@ -68,12 +69,9 @@ import Base from '../layouts/Base.astro';
   <section class="results">
     <div class="wrap">
       <!-- 01 VALUATION -->
-      <div class="sec-head">
-        <span class="num">01</span><h2>Estimated valuation</h2>
-        <span class="hint" id="val-hint"
-          >Modelled from median PSF of comparable sales in your town.</span
-        >
-      </div>
+      <SecHead num="01" title="Estimated valuation" hintId="val-hint">
+        Modelled from median PSF of comparable sales in your town.
+      </SecHead>
 
       <div class="card val-hero">
         <div class="val-main">
@@ -121,10 +119,9 @@ import Base from '../layouts/Base.astro';
       </div>
 
       <!-- 02 PRICE TRAJECTORY -->
-      <div class="sec-head">
-        <span class="num">02</span><h2>Price trajectory</h2>
-        <span class="hint" id="traj-hint">How your flat type has moved here over the years.</span>
-      </div>
+      <SecHead num="02" title="Price trajectory" hintId="traj-hint">
+        How your flat type has moved here over the years.
+      </SecHead>
 
       <div class="split" style="grid-template-columns:1.55fr 1fr">
         <div class="card chart-card">
@@ -170,10 +167,9 @@ import Base from '../layouts/Base.astro';
       </div>
 
       <!-- 03 BENCHMARKING -->
-      <div class="sec-head">
-        <span class="num">03</span><h2>How it benchmarks</h2>
-        <span class="hint" id="bench-hint">Your flat vs the town and island-wide market.</span>
-      </div>
+      <SecHead num="03" title="How it benchmarks" hintId="bench-hint">
+        Your flat vs the town and island-wide market.
+      </SecHead>
 
       <div class="bench-grid">
         <div class="card bench">
@@ -231,12 +227,9 @@ import Base from '../layouts/Base.astro';
       </div>
 
       <!-- 04 LEASE & VALUE RUNWAY -->
-      <div class="sec-head">
-        <span class="num">04</span><h2>Lease &amp; value runway</h2>
-        <span class="hint"
-          >How prices soften as the lease runs down — and the ages that affect CPF &amp; loans.</span
-        >
-      </div>
+      <SecHead num="04" title="Lease & value runway">
+        How prices soften as the lease runs down — and the ages that affect CPF & loans.
+      </SecHead>
 
       <div class="card lease-card">
         <div class="lease-top">
@@ -268,12 +261,9 @@ import Base from '../layouts/Base.astro';
       </div>
 
       <!-- 05 COMPARABLES -->
-      <div class="sec-head">
-        <span class="num">05</span><h2>Nearby comparables</h2>
-        <span class="hint" id="comp-hint"
-          >Recent sales of the same flat type in your town, same street first.</span
-        >
-      </div>
+      <SecHead num="05" title="Nearby comparables" hintId="comp-hint">
+        Recent sales of the same flat type in your town, same street first.
+      </SecHead>
 
       <div class="split">
         <div class="card comp-wrap">

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SecHead from '../components/SecHead.astro';
 ---
 
 <Base active="PSF Trends" title="PSF Trends | HDB Kaki">
@@ -67,12 +68,9 @@ import Base from '../layouts/Base.astro';
       </div>
     </div>
 
-    <div class="sec-head">
-      <span class="num">01</span><h2>PSF over time</h2>
-      <span class="hint"
-        >Each dot is a transaction (sampled); the line is the fitted trend on monthly medians.</span
-      >
-    </div>
+    <SecHead num="01" title="PSF over time">
+      Each dot is a transaction (sampled); the line is the fitted trend on monthly medians.
+    </SecHead>
     <div class="card chart-card">
       <div class="chart-head">
         <div class="chart-title" id="chart-title">Price per sqft</div><div
@@ -84,10 +82,9 @@ import Base from '../layouts/Base.astro';
       <div id="chart-psf" style="width:100%;height:420px"></div>
     </div>
 
-    <div class="sec-head">
-      <span class="num">02</span><h2>Fitted PSF by month</h2>
-      <span class="hint">Trend value read off the fit for each month.</span>
-    </div>
+    <SecHead num="02" title="Fitted PSF by month">
+      Trend value read off the fit for each month.
+    </SecHead>
     <div class="card table-card">
       <table class="comp">
         <thead

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -3,6 +3,7 @@ import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
 import FieldSelect from '../components/FieldSelect.astro';
+import DataTable from '../components/DataTable.astro';
 ---
 
 <Base active="PSF Trends" title="PSF Trends | HDB Kaki">
@@ -77,15 +78,14 @@ import FieldSelect from '../components/FieldSelect.astro';
       Trend value read off the fit for each month.
     </SecHead>
     <div class="card table-card">
-      <table class="comp">
-        <thead
-          ><tr><th>Month</th><th class="r">Trend PSF</th><th class="r">MoM change</th></tr></thead
-        >
-        <tbody id="tbody-psf"
-          ><tr><td colspan="3" style="padding:22px 16px;color:var(--ink-3)">Loading…</td></tr
-          ></tbody
-        >
-      </table>
+      <DataTable
+        headers={[
+          { label: 'Month' },
+          { label: 'Trend PSF', align: 'r' },
+          { label: 'MoM change', align: 'r' },
+        ]}
+        bodyId="tbody-psf"
+      />
       <div class="tbl-foot"><span id="psf-foot">&nbsp;</span></div>
     </div>
   </main>

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
+import ChartCard from '../components/ChartCard.astro';
 ---
 
 <Base active="PSF Trends" title="PSF Trends | HDB Kaki">
@@ -71,16 +72,10 @@ import SecHead from '../components/SecHead.astro';
     <SecHead num="01" title="PSF over time">
       Each dot is a transaction (sampled); the line is the fitted trend on monthly medians.
     </SecHead>
-    <div class="card chart-card">
-      <div class="chart-head">
-        <div class="chart-title" id="chart-title">Price per sqft</div><div
-          id="scatter-note"
-          style="font-size:12.5px;color:var(--ink-3)"
-        >
-        </div>
-      </div>
+    <ChartCard title="Price per sqft" titleId="chart-title">
+      <div id="scatter-note" slot="head" style="font-size:12.5px;color:var(--ink-3)"></div>
       <div id="chart-psf" style="width:100%;height:420px"></div>
-    </div>
+    </ChartCard>
 
     <SecHead num="02" title="Fitted PSF by month">
       Trend value read off the fit for each month.

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
+import FieldSelect from '../components/FieldSelect.astro';
 ---
 
 <Base active="PSF Trends" title="PSF Trends | HDB Kaki">
@@ -24,19 +25,14 @@ import ChartCard from '../components/ChartCard.astro';
 
   <main class="wrap pagepad">
     <div class="controls" style="margin:8px 0 22px">
-      <span class="field-select"><span class="lab">Town</span><select id="sel-town"></select></span>
-      <span class="field-select"
-        ><span class="lab">Street</span><select id="sel-street"></select></span
-      >
-      <span class="field-select"
-        ><span class="lab">Storey</span>
-        <select id="sel-storey">
-          <option value="all" selected>All</option>
-          <option value="1-6">01–06</option>
-          <option value="7-12">07–12</option>
-          <option value="13-99">13+</option>
-        </select>
-      </span>
+      <FieldSelect label="Town" id="sel-town" />
+      <FieldSelect label="Street" id="sel-street" />
+      <FieldSelect label="Storey" id="sel-storey">
+        <option value="all" selected>All</option>
+        <option value="1-6">01–06</option>
+        <option value="7-12">07–12</option>
+        <option value="13-99">13+</option>
+      </FieldSelect>
       <div class="chipset" id="reg-toggle">
         <button class="chip on" data-reg="ols">OLS</button>
         <button class="chip" data-reg="loess">LOWESS</button>

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
+import ChartCard from '../components/ChartCard.astro';
 ---
 
 <Base active="Town Analysis" title="Town Analysis | HDB Kaki">
@@ -85,12 +86,9 @@ import SecHead from '../components/SecHead.astro';
         <button class="chip" data-scope="global">All Singapore</button>
       </div>
     </div>
-    <div class="card chart-card">
-      <div class="chart-head">
-        <div class="chart-title" id="record-title">Most expensive on record</div>
-        <div class="chart-sub">
-          Ranked by peak transaction · median for that flat type shown for scale
-        </div>
+    <ChartCard title="Most expensive on record" titleId="record-title">
+      <div class="chart-sub" slot="head">
+        Ranked by peak transaction · median for that flat type shown for scale
       </div>
       <div class="lead" id="record-list"></div>
       <div class="rec-foot">
@@ -100,7 +98,7 @@ import SecHead from '../components/SecHead.astro';
           <button class="ghost pg" id="rec-next" disabled>Next →</button>
         </span>
       </div>
-    </div>
+    </ChartCard>
 
     <!-- 03 · DATA TABLE -->
     <SecHead num="03" title="Data behind the map"> Every point currently in view. </SecHead>

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -4,6 +4,7 @@ import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
 import FieldSelect from '../components/FieldSelect.astro';
 import Pager from '../components/Pager.astro';
+import DataTable from '../components/DataTable.astro';
 ---
 
 <Base active="Town Analysis" title="Town Analysis | HDB Kaki">
@@ -95,19 +96,17 @@ import Pager from '../components/Pager.astro';
     <!-- 03 · DATA TABLE -->
     <SecHead num="03" title="Data behind the map"> Every point currently in view. </SecHead>
     <div class="card table-card">
-      <table class="comp">
-        <thead
-          ><tr
-            ><th>Sold</th><th>Address</th><th class="r">Price</th><th class="r">PSF</th><th
-              class="r">Lease left</th
-            ><th>Band</th></tr
-          ></thead
-        >
-        <tbody id="tbody-town"
-          ><tr><td colspan="6" style="padding:22px 16px;color:var(--ink-3)">Loading…</td></tr
-          ></tbody
-        >
-      </table>
+      <DataTable
+        headers={[
+          { label: 'Sold' },
+          { label: 'Address' },
+          { label: 'Price', align: 'r' },
+          { label: 'PSF', align: 'r' },
+          { label: 'Lease left', align: 'r' },
+          { label: 'Band' },
+        ]}
+        bodyId="tbody-town"
+      />
       <div class="tbl-foot">
         <span id="town-foot">&nbsp;</span><a class="ghost" href="#" id="dl-town"
           >Download data in view (CSV) ↓</a

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import SecHead from '../components/SecHead.astro';
 ---
 
 <Base active="Town Analysis" title="Town Analysis | HDB Kaki">
@@ -18,12 +19,9 @@ import Base from '../layouts/Base.astro';
 
   <main class="wrap pagepad">
     <!-- 01 · PRICE MAP -->
-    <div class="sec-head rise">
-      <span class="num">01</span><h2>Price map</h2>
-      <span class="hint"
-        >Each pin is a sale in the last 24 months, coloured relative to the town median.</span
-      >
-    </div>
+    <SecHead num="01" title="Price map" rise>
+      Each pin is a sale in the last 24 months, coloured relative to the town median.
+    </SecHead>
 
     <div class="controls" style="margin-bottom:16px">
       <span class="field-select"><span class="lab">Town</span><select id="sel-town"></select></span>
@@ -76,14 +74,11 @@ import Base from '../layouts/Base.astro';
     </div>
 
     <!-- 02 · RECORD SALES -->
-    <div class="sec-head">
-      <span class="num">02</span><h2>Record sales</h2>
-      <span class="hint"
-        >The most expensive sales on record — a town's own peaks, or the record per town across
-        Singapore. These are outliers — big units, high floors, prime blocks — shown with context,
-        not typical prices.</span
-      >
-    </div>
+    <SecHead num="02" title="Record sales">
+      The most expensive sales on record — a town's own peaks, or the record per town across
+      Singapore. These are outliers — big units, high floors, prime blocks — shown with context, not
+      typical prices.
+    </SecHead>
     <div class="controls" style="margin-bottom:16px">
       <div class="chipset" id="record-scope">
         <button class="chip on" data-scope="town">This town</button>
@@ -108,10 +103,7 @@ import Base from '../layouts/Base.astro';
     </div>
 
     <!-- 03 · DATA TABLE -->
-    <div class="sec-head">
-      <span class="num">03</span><h2>Data behind the map</h2>
-      <span class="hint">Every point currently in view.</span>
-    </div>
+    <SecHead num="03" title="Data behind the map"> Every point currently in view. </SecHead>
     <div class="card table-card">
       <table class="comp">
         <thead

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -5,6 +5,7 @@ import ChartCard from '../components/ChartCard.astro';
 import FieldSelect from '../components/FieldSelect.astro';
 import Pager from '../components/Pager.astro';
 import DataTable from '../components/DataTable.astro';
+import LeafletMap from '../components/LeafletMap.astro';
 ---
 
 <Base active="Town Analysis" title="Town Analysis | HDB Kaki">
@@ -39,7 +40,7 @@ import DataTable from '../components/DataTable.astro';
     </div>
 
     <div class="split" style="grid-template-columns:1.55fr 1fr">
-      <div id="map" class="map-real"></div>
+      <LeafletMap id="map" height="472px" />
       <div class="card" style="padding:24px">
         <div class="cap">Median resale price</div>
         <div style="display:flex;align-items:baseline;gap:10px;margin-bottom:4px">
@@ -117,14 +118,6 @@ import DataTable from '../components/DataTable.astro';
 </Base>
 
 <style>
-  .map-real {
-    height: 472px;
-    border-radius: var(--radius);
-    border: 1px solid var(--line);
-    box-shadow: var(--shadow);
-    overflow: hidden;
-    z-index: 0;
-  }
   .cap {
     font-size: 12px;
     font-weight: 600;
@@ -261,29 +254,6 @@ import DataTable from '../components/DataTable.astro';
     border-top: 1px solid var(--line);
     font-size: 13px;
     color: var(--ink-3);
-  }
-  /* Leaflet hover tooltip on-brand */
-  :global(.leaflet-container) {
-    font-family: var(--font-sans);
-    background: #f3ede1;
-  }
-  :global(.leaflet-tooltip.hdb-tip) {
-    background: var(--paper-2);
-    border: 1px solid var(--line);
-    border-radius: 10px;
-    box-shadow: var(--shadow);
-    color: var(--ink);
-    font-family: var(--font-sans);
-    font-size: 13px;
-    padding: 9px 12px;
-    line-height: 1.5;
-    white-space: nowrap;
-  }
-  :global(.leaflet-tooltip.hdb-tip b) {
-    font-weight: 600;
-  }
-  :global(.leaflet-tooltip-top.hdb-tip::before) {
-    border-top-color: var(--paper-2);
   }
 </style>
 

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
+import FieldSelect from '../components/FieldSelect.astro';
 ---
 
 <Base active="Town Analysis" title="Town Analysis | HDB Kaki">
@@ -25,21 +26,14 @@ import ChartCard from '../components/ChartCard.astro';
     </SecHead>
 
     <div class="controls" style="margin-bottom:16px">
-      <span class="field-select"><span class="lab">Town</span><select id="sel-town"></select></span>
-      <span class="field-select"
-        ><span class="lab">Street</span><select id="sel-street"></select></span
-      >
-      <span class="field-select"
-        ><span class="lab">Flat type</span><select id="sel-flat"></select></span
-      >
-      <span class="field-select"
-        ><span class="lab">Threshold</span>
-        <select id="sel-thr"
-          ><option value="0.05">±5%</option><option value="0.1" selected>±10%</option><option
-            value="0.15">±15%</option
-          ></select
-        >
-      </span>
+      <FieldSelect label="Town" id="sel-town" />
+      <FieldSelect label="Street" id="sel-street" />
+      <FieldSelect label="Flat type" id="sel-flat" />
+      <FieldSelect label="Threshold" id="sel-thr">
+        <option value="0.05">±5%</option>
+        <option value="0.1" selected>±10%</option>
+        <option value="0.15">±15%</option>
+      </FieldSelect>
     </div>
 
     <div class="split" style="grid-template-columns:1.55fr 1fr">

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -3,6 +3,7 @@ import Base from '../layouts/Base.astro';
 import SecHead from '../components/SecHead.astro';
 import ChartCard from '../components/ChartCard.astro';
 import FieldSelect from '../components/FieldSelect.astro';
+import Pager from '../components/Pager.astro';
 ---
 
 <Base active="Town Analysis" title="Town Analysis | HDB Kaki">
@@ -87,10 +88,7 @@ import FieldSelect from '../components/FieldSelect.astro';
       <div class="lead" id="record-list"></div>
       <div class="rec-foot">
         <span id="record-foot">&nbsp;</span>
-        <span class="pager">
-          <button class="ghost pg" id="rec-prev" disabled>← Prev</button>
-          <button class="ghost pg" id="rec-next" disabled>Next →</button>
-        </span>
+        <Pager />
       </div>
     </ChartCard>
 
@@ -252,8 +250,8 @@ import FieldSelect from '../components/FieldSelect.astro';
       white-space: normal;
     }
   }
-  /* Pager footer — mirrors the Recent-transactions pager on the landing page. The
-     negative side margins bleed the divider to the card edges past .chart-card's padding. */
+  /* Record-sales footer holding the <Pager>. The negative side margins bleed the
+     divider to the card edges past .chart-card's padding. */
   .rec-foot {
     display: flex;
     justify-content: space-between;
@@ -264,19 +262,6 @@ import FieldSelect from '../components/FieldSelect.astro';
     border-top: 1px solid var(--line);
     font-size: 13px;
     color: var(--ink-3);
-  }
-  .pager {
-    display: inline-flex;
-    gap: 8px;
-  }
-  .pager .pg {
-    padding: 7px 13px;
-    font-size: 13px;
-  }
-  .pager .pg:disabled {
-    opacity: 0.4;
-    cursor: default;
-    border-color: var(--line);
   }
   /* Leaflet hover tooltip on-brand */
   :global(.leaflet-container) {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -246,6 +246,20 @@ h1.title em {
 .ghost:hover {
   border-color: var(--ink);
 }
+/* Compact ghost-button pager — Recent transactions (landing) and Record sales (town). */
+.pager {
+  display: inline-flex;
+  gap: 8px;
+}
+.pager .pg {
+  padding: 7px 13px;
+  font-size: 13px;
+}
+.pager .pg:disabled {
+  opacity: 0.4;
+  cursor: default;
+  border-color: var(--line);
+}
 
 /* ---------- footer ---------- */
 footer {


### PR DESCRIPTION
## What

Extracts six reusable Astro components from markup that was copy-pasted across the four pages. Before this, `web/src/components/` held only `Nav` and `Footer` — the CSS was centralised in `global.css`, but the markup using it was duplicated page to page.

| Component | Replaces | Notes |
|-----------|----------|-------|
| `SecHead` | 15× numbered section headers | `num`, `title`, optional `rise`, `hintId` (deck via slot) |
| `ChartCard` | 10× `card + chart-head + chart-title` shells | `head` slot for pill/note/sub; body via default slot |
| `FieldSelect` | 9× labelled filter `<select>`s | static `<option>`s via slot; script-populated ones leave it empty |
| `Pager` | 2× prev/next pagers | `.pager` CSS (duplicated in two scoped `<style>`s) hoisted to `global.css` |
| `DataTable` | 4× `table.comp` header + loading row | headers/colspan/placeholder from props; card + footer stay per-page |
| `LeafletMap` | 2× `.map-real` box + `.leaflet-*` overrides | overrides kept in the component `<style>` so they still load after Leaflet's stylesheet and win by source order |

Each component is its own commit.

## Why

Removes the largest blocks of duplicated markup, gives each pattern one source of truth, and starts actually using the components directory. Net change is smaller pages plus six small components.

## Preserving behaviour

Every DOM id the scripts and Playwright specs depend on is passed through as a prop (`rec-prev`, `sel-town`, `chart-trends`, `map`, `ins-map`, `tbody-*`, …) — nothing was renamed. The refactor is markup-only; no page `<script>` was touched.

## Verification

- `astro check` — 0 errors; `astro build` — all 4 pages build; `eslint` — 0 errors; `prettier` — clean.
- Browser render (all pages): SecHead / ChartCard / FieldSelect / DataTable / Pager / LeafletMap all render — landing recent table paginates, PSF trends fully renders, town-analysis map + table populate (`Ang Mo Kio · 4 Room · 616 sales`, 12 rows), both Leaflet maps mount.
- The e2e specs that regenerate `public/data/` in CI will exercise the DuckDB paths; locally those snapshots are gitignored.

## Follow-up

The per-page client `<script>` blocks still re-declare shared scaffolding (lazy DuckDB `query`, `warmEngineWhenIdle`, `byId`/`sqlEsc`, `setStreets`/`loadStreets`, delta-pill formatting). That belongs in `src/lib/`, not `.astro` files — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
