### PR TITLE
fix(web): auto-resize charts when their container settles late

### DIFF
--- a/web/src/lib/echarts.ts
+++ b/web/src/lib/echarts.ts
@@ -32,5 +32,21 @@ echarts.use([
   CanvasRenderer,
 ]);
 
+// Wrap echarts.init with a ResizeObserver on the container. The pages only listen
+// for window 'resize', which fires on viewport changes but NOT when a chart's own
+// box settles late — e.g. a grid/flex column resolving its width after init, or a
+// web-font swap reflowing the layout. When that happens a chart initialised at ~0
+// width stays collapsed until the next manual resize. Observing the container makes
+// it recover automatically. (ResizeObserver fires once on observe, so this also
+// covers the first post-layout paint.)
+export function initChart(el: HTMLElement): echarts.ECharts {
+  const chart = echarts.init(el);
+  if (typeof ResizeObserver !== 'undefined') {
+    const ro = new ResizeObserver(() => chart.resize());
+    ro.observe(el);
+  }
+  return chart;
+}
+
 export default echarts;
 export { echarts };

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -215,7 +215,7 @@ const kpis = stats
 </style>
 
 <script>
-  import echarts from '../lib/echarts';
+  import echarts, { initChart } from '../lib/echarts';
   import {
     baseOption,
     palette,
@@ -399,7 +399,7 @@ const kpis = stats
     // there's room; on narrow screens the map stays clean and a tap reveals the tooltip.
     const showLabels = level === 'town' && labelsFit();
 
-    mapChart ??= echarts.init(q('chart-map'));
+    mapChart ??= initChart(q('chart-map'));
     mapChart.setOption(
       {
         ...baseOption(),
@@ -496,7 +496,7 @@ const kpis = stats
   // ---- 03 box plot by town ----
   function renderBox() {
     const rows = OV.box;
-    const chart = echarts.init(q('chart-box'));
+    const chart = initChart(q('chart-box'));
     chart.setOption({
       ...baseOption(),
       grid: { left: 64, right: 20, top: 20, bottom: 78, containLabel: false },
@@ -539,7 +539,7 @@ const kpis = stats
       '81-99 years': palette[2],
     };
     const pts = OV.scatter;
-    const scatter = echarts.init(q('chart-scatter'));
+    const scatter = initChart(q('chart-scatter'));
     scatter.setOption({
       ...baseOption(),
       grid: { left: 62, right: 20, top: 30, bottom: 44, containLabel: false },
@@ -574,7 +574,7 @@ const kpis = stats
     });
 
     const counts = OV.buckets;
-    const buckets = echarts.init(q('chart-buckets'));
+    const buckets = initChart(q('chart-buckets'));
     buckets.setOption({
       ...baseOption(),
       grid: { left: 90, right: 40, top: 20, bottom: 30, containLabel: false },
@@ -726,7 +726,7 @@ const kpis = stats
     });
     // Replace the SSR placeholder SVG with the interactive canvas chart in one step.
     q('chart-trends').innerHTML = '';
-    trendChart = echarts.init(q('chart-trends'));
+    trendChart = initChart(q('chart-trends'));
     renderTrends('lease');
     renderMap('town').catch((e) => console.error(e));
     renderBox();

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -892,7 +892,7 @@ import LeafletMap from '../components/LeafletMap.astro';
   // first query. (Idempotent: primes the same _db the query wrapper reuses.)
   _db = import('../lib/db');
   _db.then((m) => m.prefetch()).catch(() => {});
-  import echarts from '../lib/echarts';
+  import echarts, { initChart } from '../lib/echarts';
   import {
     baseOption,
     palette,
@@ -915,7 +915,7 @@ import LeafletMap from '../components/LeafletMap.astro';
 
   // ---- ECharts: init once per container, reuse across recomputes ----
   const charts: Record<string, echarts.ECharts> = {};
-  const ec = (id: string) => (charts[id] ??= echarts.init($(id)));
+  const ec = (id: string) => (charts[id] ??= initChart($(id)));
   // State the "returns" panel needs so it can recompute on input change without re-querying.
   let currentEstimate = 0;
   let townYearPrice: Record<string, number> = {}; // 'YYYY' -> town median price for the flat type

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -109,7 +109,7 @@ import DataTable from '../components/DataTable.astro';
 </style>
 
 <script>
-  import echarts from '../lib/echarts';
+  import echarts, { initChart } from '../lib/echarts';
   import { regressionLinear, regressionLoess } from 'd3-regression';
   // DuckDB-WASM is heavy and NOT needed for first paint: the default view renders from
   // a precomputed snapshot (psf-trends.json). The engine is imported lazily and only
@@ -140,7 +140,7 @@ import DataTable from '../components/DataTable.astro';
   const monthLabel = (idx: number) =>
     `${2017 + Math.floor(idx / 12)}-${String((idx % 12) + 1).padStart(2, '0')}`;
 
-  const chart = echarts.init($('chart-psf'));
+  const chart = initChart($('chart-psf'));
   let regType: 'ols' | 'loess' = 'ols';
   let fullMinIdx = 0,
     fullMaxIdx = 0; // full x-extent, for mapping zoom % → months

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -109,7 +109,7 @@ import DataTable from '../components/DataTable.astro';
 </style>
 
 <script>
-  import echarts, { initChart } from '../lib/echarts';
+  import { initChart } from '../lib/echarts';
   import { regressionLinear, regressionLoess } from 'd3-regression';
   // DuckDB-WASM is heavy and NOT needed for first paint: the default view renders from
   // a precomputed snapshot (psf-trends.json). The engine is imported lazily and only


### PR DESCRIPTION
## Problem

The scatter on the Market Overview page ("Price & remaining lease", section 04) intermittently renders **collapsed** — all points stacked on a single x-value, axis labels piled up, legend wrapped to the left. That's the classic ECharts symptom of a chart **initialised before its container had a width**: a grid/flex column that hadn't resolved its width yet, or a late web-font swap reflowing the layout.

Every page only listens for `window.resize`, which fires on viewport changes but **not** when a chart's own box settles after init — so a chart that came up at ~0 width stays collapsed until the user happens to resize the window.

This is pre-existing (not introduced by the info-button work); it just surfaces most visibly on the dense scatter.

## Fix

Add an `initChart()` helper in `src/lib/echarts.ts` that wraps `echarts.init` with a `ResizeObserver` on the container, and route every chart init through it (index ×5, my-flat-insights, psf-trends). `ResizeObserver` fires on any container box change — including the first post-layout paint — so a chart that started narrow recovers automatically.

## Verification

- Production build passes; prettier + eslint pass.
- Drove the built site with Playwright: forced `#chart-scatter`'s container to 240px and back **without dispatching a window resize** — the canvas tracked `602 → 240 → 602`, which only a `ResizeObserver` (not the old window-only handler) can do. Confirms the recovery path for the init-before-layout race.
- Charts render normally otherwise (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)