### PR TITLE
refactor(web): extract shared client-script scaffolding into src/lib (#49)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -26,7 +26,7 @@
         "playwright-core": "^1.61.1",
         "prettier": "^3.9.5",
         "prettier-plugin-astro": "^0.14.1",
-        "typescript": "5",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.64.0",
         "wrangler": "^4.112.0",
       },

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,7 @@
     "playwright-core": "^1.61.1",
     "prettier": "^3.9.5",
     "prettier-plugin-astro": "^0.14.1",
-    "typescript": "5",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.64.0",
     "wrangler": "^4.112.0"
   }

--- a/web/src/lib/duckdbClient.ts
+++ b/web/src/lib/duckdbClient.ts
@@ -1,0 +1,74 @@
+// Shared client-side scaffolding for the interactive pages' <script> blocks.
+//
+// The DuckDB-WASM engine (~4.7 MB) must stay OUT of each page's first-paint bundle,
+// so it is only ever pulled in via a *dynamic* import('./db'). createQuery() closes
+// over that single lazy import so query() and the warm/prefetch helpers all share one
+// engine instance and never double-download it. Because these helpers touch DOM /
+// browser globals only when called, this module is import-safe in a client script but
+// must not be imported into SSR frontmatter.
+import { titleCase } from './format';
+
+type DbModule = typeof import('./db');
+export type QueryFn = <T = any>(sql: string) => Promise<T[]>;
+
+/** `document.getElementById(id)` with a non-null assertion — the ids are in the template. */
+export const byId = (id: string): HTMLElement => document.getElementById(id)!;
+
+/** Escape single quotes for interpolation into a SQL string literal. */
+export const sqlEsc = (s: unknown): string => String(s).replace(/'/g, "''");
+
+/**
+ * A lazily-booted DuckDB query interface for one page. All three returned functions
+ * share the same dynamic import(), so warming and querying reuse a single engine:
+ *  - `query(sql)`  — run SQL against the `resale` view (boots the engine on first call).
+ *  - `prefetch()`  — boot the engine now (download + instantiate + register), so the
+ *                    first query resolves instantly. Idempotent.
+ *  - `warmEngineWhenIdle()` — prefetch at idle time, unless Save-Data is on; and, while
+ *                    the page is only being speculatively prerendered (from a hover),
+ *                    defer the ~4.7 MB download until the prerender is activated.
+ */
+export function createQuery(): {
+  query: QueryFn;
+  prefetch: () => void;
+  warmEngineWhenIdle: () => void;
+} {
+  let db: Promise<DbModule> | null = null;
+  const load = () => (db ??= import('./db'));
+
+  const query: QueryFn = async <T = any>(sql: string): Promise<T[]> => (await load()).query<T>(sql);
+
+  const prefetch = () => {
+    load()
+      .then((m) => m.prefetch())
+      .catch(() => {});
+  };
+
+  const warmEngineWhenIdle = () => {
+    if ((navigator as any).connection?.saveData) return;
+    const idle: (cb: () => void) => void =
+      (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
+    const warm = () => idle(prefetch);
+    if ((document as any).prerendering) {
+      document.addEventListener('prerenderingchange', warm, { once: true });
+    } else {
+      warm();
+    }
+  };
+
+  return { query, prefetch, warmEngineWhenIdle };
+}
+
+/** Populate a street `<select>` with an "All streets" option plus one option per street. */
+export function setStreets(selectEl: HTMLElement, streets: string[]): void {
+  (selectEl as HTMLSelectElement).innerHTML =
+    `<option value="__all" selected>All streets</option>` +
+    streets.map((s) => `<option value="${s}">${titleCase(s)}</option>`).join('');
+}
+
+/** Distinct street names in a town, ordered — for the street filter dropdown. */
+export async function loadStreets(query: QueryFn, town: string): Promise<string[]> {
+  const streets = await query<{ street_name: string }>(
+    `SELECT DISTINCT street_name FROM resale WHERE town='${sqlEsc(town)}' ORDER BY street_name`,
+  );
+  return streets.map((s) => s.street_name);
+}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -13,6 +13,21 @@ export const psf = (n: number): string => '$' + Math.round(n);
 export const pct = (n: number): string => (n >= 0 ? '+' : '') + n.toFixed(1) + '%';
 
 /**
+ * Format a signed percentage delta into the parts of a `.pill` badge: a `up | down |
+ * flat` class, a `▲ | ▼` arrow, and the `▲ X.X%` text. `threshold` is the dead-band
+ * around zero that reads as "flat" (0 → never flat, just up/down by sign); it varies
+ * per call site (0 / 0.5 / 1). `digits` controls the decimal places on the magnitude.
+ */
+export const deltaPill = (
+  n: number,
+  { threshold = 0, digits = 1 }: { threshold?: number; digits?: number } = {},
+): { cls: 'up' | 'down' | 'flat'; arrow: '▲' | '▼'; text: string } => {
+  const cls = n >= threshold ? 'up' : n <= -threshold ? 'down' : 'flat';
+  const arrow = n >= 0 ? '▲' : '▼';
+  return { cls, arrow, text: `${arrow} ${Math.abs(n).toFixed(digits)}%` };
+};
+
+/**
  * Title-case a SCREAMING town/flat/address label, e.g. "ANG MO KIO" -> "Ang Mo Kio".
  * A letter that directly follows a digit is kept uppercase so HDB block and lane
  * suffixes read correctly, e.g. "138A LOR 1A TOA PAYOH" -> "138A Lor 1A Toa Payoh".

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import { trendsSVG } from '../lib/echartsSSR';
-import { moneyShort, psf as fpsf } from '../lib/format';
+import { moneyShort, psf as fpsf, deltaPill } from '../lib/format';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -25,9 +25,6 @@ try {
 
 // Redfin-style hero KPI strip: a headline value + its year-on-year delta each.
 const int = (n: number | null) => (n == null ? '—' : n.toLocaleString('en-SG'));
-const dCls = (n: number | null) => (n == null ? 'flat' : n >= 0 ? 'up' : 'down');
-const dTxt = (n: number | null) =>
-  n == null ? 'n/a' : `${n >= 0 ? '▲' : '▼'} ${Math.abs(n).toFixed(1)}% YoY`;
 const kpis = stats
   ? [
       {
@@ -76,13 +73,16 @@ const kpis = stats
             style="animation-delay:.15s"
             aria-label="Market at a glance, last 12 months"
           >
-            {kpis.map((k) => (
-              <div class="kpi">
-                <span class="kpi-cap">{k.cap}</span>
-                <span class="kpi-val mono">{k.val}</span>
-                <span class={`pill ${dCls(k.yoy)}`}>{dTxt(k.yoy)}</span>
-              </div>
-            ))}
+            {kpis.map((k) => {
+              const d = k.yoy == null ? null : deltaPill(k.yoy);
+              return (
+                <div class="kpi">
+                  <span class="kpi-cap">{k.cap}</span>
+                  <span class="kpi-val mono">{k.val}</span>
+                  <span class={`pill ${d?.cls ?? 'flat'}`}>{d ? `${d.text} YoY` : 'n/a'}</span>
+                </div>
+              );
+            })}
           </div>
         )
       }
@@ -254,6 +254,7 @@ const kpis = stats
     mono,
   } from '../lib/echartsTheme';
   import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
+  import { createQuery, sqlEsc, byId as q } from '../lib/duckdbClient';
 
   // Landing renders from a single precomputed aggregate (webapp/update/emit_web.py), so
   // the default view never boots DuckDB-WASM. The one exception is the recent-
@@ -273,16 +274,9 @@ const kpis = stats
   };
   let OV: Overview;
 
-  const q = (id: string) => document.getElementById(id)!;
-
   // Lazily-imported DuckDB engine, shared with the idle warm below so we never double-
   // download it. Only the recent-transactions filters/pager reach for this.
-  let _db: Promise<typeof import('../lib/db')> | null = null;
-  const query = async <T = any,>(sqlText: string): Promise<T[]> => {
-    if (!_db) _db = import('../lib/db');
-    return (await _db).query<T>(sqlText);
-  };
-  const sqlEsc = (s: string) => s.replace(/'/g, "''");
+  const { query, warmEngineWhenIdle } = createQuery();
 
   // ---- 01 price trends (with lens toggle) ----
   // Initialised in boot(), after data loads, so the SSR placeholder SVG stays
@@ -771,25 +765,6 @@ const kpis = stats
   // imported to stay out of the landing bundle and deferred to idle so it never
   // competes with the landing's own render. Skipped under Save-Data.
   warmEngineWhenIdle();
-  function warmEngineWhenIdle() {
-    if ((navigator as any).connection?.saveData) return;
-    const idle: (cb: () => void) => void =
-      (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
-    const warm = () =>
-      idle(() => {
-        _db ??= import('../lib/db');
-        _db.then((m) => m.prefetch()).catch(() => {});
-      });
-    // This link is a clientPrerender target: while the page is only being speculatively
-    // prerendered (from a hover), don't download the ~4.7 MB DuckDB wasm — a hover
-    // shouldn't pull the engine for a page never visited. Defer the warm until the
-    // prerender is activated into a real navigation.
-    if ((document as any).prerendering) {
-      document.addEventListener('prerenderingchange', warm, { once: true });
-    } else {
-      warm();
-    }
-  }
 
   // Re-render the map when a resize crosses the 640px breakpoint (e.g. phone rotation):
   // the legend flips to horizontal and the framing shifts, and town labels appear or

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -910,16 +910,13 @@ import Base from '../layouts/Base.astro';
   import L from 'leaflet';
   // DuckDB-WASM is heavy; load it lazily so the page shell is interactive first and
   // the engine only downloads when the user runs a valuation.
-  let _db: Promise<typeof import('../lib/db')> | null = null;
-  const query = async <T = any,>(sql: string): Promise<T[]> => {
-    if (!_db) _db = import('../lib/db');
-    return (await _db).query<T>(sql);
-  };
+  import { createQuery, sqlEsc as sql, byId as $ } from '../lib/duckdbClient';
+
+  const { query, prefetch } = createQuery();
   // This page auto-computes a default valuation on load, so start warming the engine
   // now — overlapping the WASM download with DOM wiring instead of waiting for the
-  // first query. (Idempotent: primes the same _db the query wrapper reuses.)
-  _db = import('../lib/db');
-  _db.then((m) => m.prefetch()).catch(() => {});
+  // first query. (Idempotent: primes the same lazy import the query wrapper reuses.)
+  prefetch();
   import echarts from '../lib/echarts';
   import {
     baseOption,
@@ -930,11 +927,9 @@ import Base from '../layouts/Base.astro';
     ink3,
     red,
   } from '../lib/echartsTheme';
-  import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
+  import { money, moneyShort, psf as fpsf, titleCase, deltaPill } from '../lib/format';
   import { reformatWithCaret, parsePrice, computeReturns } from '../lib/returns';
 
-  const $ = (id: string) => document.getElementById(id)!;
-  const sql = (s: string) => String(s).replace(/'/g, "''");
   const NOW_YEAR = new Date().getFullYear();
 
   let block = { town: '', street: '', address: '', model: '', lc: 0 };
@@ -962,9 +957,6 @@ import Base from '../layouts/Base.astro';
       hi = Math.ceil(i);
     return sorted[lo] + (sorted[hi] - sorted[lo]) * (i - lo);
   };
-  const pillClass = (d: number) => (d >= 1 ? 'up' : d <= -1 ? 'down' : 'flat');
-  const arrow = (d: number) => (d >= 0 ? '▲' : '▼');
-
   // ---- Leaflet map ----
   const map = L.map('ins-map', { scrollWheelZoom: false }).setView([1.3521, 103.8198], 12);
   L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
@@ -1064,8 +1056,9 @@ import Base from '../layouts/Base.astro';
     $('traj-hint').textContent =
       `Median PSF for ${flat.toLowerCase()} flats in ${titleCase(town)}, ${first.yr}–${last.yr}.`;
     const pill = $('traj-pill');
-    pill.className = `pill ${growth >= 0 ? 'up' : 'down'}`;
-    pill.textContent = `${growth >= 0 ? '▲' : '▼'} ${Math.abs(growth).toFixed(0)}% since ${first.yr}`;
+    const g = deltaPill(growth, { digits: 0 });
+    pill.className = `pill ${g.cls}`;
+    pill.textContent = `${g.text} since ${first.yr}`;
     el.setOption({
       ...baseOption(),
       grid: { left: 52, right: 18, top: 18, bottom: 30, containLabel: false },
@@ -1393,18 +1386,20 @@ import Base from '../layouts/Base.astro';
         .join('');
     };
     const dPsf = islandPsf ? (medPsf / islandPsf - 1) * 100 : 0;
+    const psfPill = deltaPill(dPsf, { threshold: 1 });
     $('b1-v').textContent = fpsf(medPsf);
-    $('b1-pill').className = `pill ${pillClass(dPsf)}`;
-    $('b1-pill').textContent = `${arrow(dPsf)} ${Math.abs(dPsf).toFixed(1)}% vs island`;
+    $('b1-pill').className = `pill ${psfPill.cls}`;
+    $('b1-pill').textContent = `${psfPill.text} vs island`;
     $('b1-bars').innerHTML = bar([
       { lab: 'This flat', val: medPsf, you: true, fmt: fpsf },
       { lab: 'Island', val: islandPsf, fmt: fpsf },
     ]);
 
     const dPrice = townPrice ? (estimate / townPrice - 1) * 100 : 0;
+    const pricePill = deltaPill(dPrice, { threshold: 1 });
     $('b2-v').textContent = moneyShort(estimate);
-    $('b2-pill').className = `pill ${pillClass(dPrice)}`;
-    $('b2-pill').textContent = `${arrow(dPrice)} ${Math.abs(dPrice).toFixed(1)}% vs town`;
+    $('b2-pill').className = `pill ${pricePill.cls}`;
+    $('b2-pill').textContent = `${pricePill.text} vs town`;
     $('b2-bars').innerHTML = bar([
       { lab: 'This flat', val: estimate, you: true, fmt: moneyShort },
       { lab: `${titleCase(block.town)}`, val: townPrice, fmt: moneyShort },
@@ -1412,12 +1407,11 @@ import Base from '../layouts/Base.astro';
     ]);
 
     const dArea = townArea ? (area / townArea - 1) * 100 : 0;
+    const areaPill = deltaPill(dArea, { threshold: 1, digits: 0 });
     $('b3-v').textContent = `${area.toLocaleString()} sqft`;
-    $('b3-pill').className = `pill ${Math.abs(dArea) < 3 ? 'flat' : pillClass(dArea)}`;
+    $('b3-pill').className = `pill ${Math.abs(dArea) < 3 ? 'flat' : areaPill.cls}`;
     $('b3-pill').textContent =
-      Math.abs(dArea) < 3
-        ? '≈ typical for type'
-        : `${arrow(dArea)} ${Math.abs(dArea).toFixed(0)}% vs town`;
+      Math.abs(dArea) < 3 ? '≈ typical for type' : `${areaPill.text} vs town`;
     $('b3-bars').innerHTML = bar([
       { lab: 'This flat', val: area, you: true, fmt: (v) => v.toLocaleString() },
       {

--- a/web/src/pages/psf-trends.astro
+++ b/web/src/pages/psf-trends.astro
@@ -115,11 +115,6 @@ import Base from '../layouts/Base.astro';
   // DuckDB-WASM is heavy and NOT needed for first paint: the default view renders from
   // a precomputed snapshot (psf-trends.json). The engine is imported lazily and only
   // booted when the visitor changes a filter or zooms (warmed on idle so that's snappy).
-  let _db: Promise<typeof import('../lib/db')> | null = null;
-  const query = async <T = any,>(sql: string): Promise<T[]> => {
-    if (!_db) _db = import('../lib/db');
-    return (await _db).query<T>(sql);
-  };
   import {
     baseOption,
     axisLabel,
@@ -129,10 +124,16 @@ import Base from '../layouts/Base.astro';
     line as lineCol,
     red,
   } from '../lib/echartsTheme';
-  import { money, psf as fpsf, titleCase } from '../lib/format';
+  import { money, psf as fpsf, titleCase, deltaPill } from '../lib/format';
+  import {
+    createQuery,
+    sqlEsc as sql,
+    byId as $,
+    setStreets,
+    loadStreets,
+  } from '../lib/duckdbClient';
 
-  const $ = (id: string) => document.getElementById(id)!;
-  const sql = (s: string) => s.replace(/'/g, "''");
+  const { query, warmEngineWhenIdle } = createQuery();
   const START = '2020-01';
 
   const SCATTER_CAP = 6000; // reservoir-sample the dots above this; stats/trend use the full set
@@ -365,11 +366,8 @@ import Base from '../layouts/Base.astro';
       $('stat-psf').textContent = fpsf(lastF);
       if (prev) {
         const prevF = fitted.get(prev.idx) ?? prev.med;
-        const d = ((lastF - prevF) / prevF) * 100;
-        const cls = d >= 0.5 ? 'up' : d <= -0.5 ? 'down' : 'flat';
-        const arrow = d >= 0 ? '▲' : '▼';
-        $('stat-delta').innerHTML =
-          `<span class="pill ${cls}">${arrow} ${Math.abs(d).toFixed(1)}%</span> vs last month`;
+        const { cls, text } = deltaPill(((lastF - prevF) / prevF) * 100, { threshold: 0.5 });
+        $('stat-delta').innerHTML = `<span class="pill ${cls}">${text}</span> vs last month`;
       }
       $('stat-r2').textContent = isNaN(r2) ? '—' : r2.toFixed(2);
       $('stat-fit').textContent = isNaN(r2)
@@ -391,9 +389,8 @@ import Base from '../layouts/Base.astro';
         let mom = '';
         if (nxt) {
           const fn = fitted.get(nxt.idx) ?? nxt.med;
-          const d = ((f - fn) / fn) * 100;
-          const cls = d >= 0.5 ? 'up' : d <= -0.5 ? 'down' : 'flat';
-          mom = `<span class="pill ${cls}">${d >= 0 ? '▲' : '▼'} ${Math.abs(d).toFixed(1)}%</span>`;
+          const { cls, text } = deltaPill(((f - fn) / fn) * 100, { threshold: 0.5 });
+          mom = `<span class="pill ${cls}">${text}</span>`;
         }
         return `<tr><td class="num-cell">${p.month}</td><td class="r price">${fpsf(f)}</td><td class="r">${mom}</td></tr>`;
       })
@@ -410,19 +407,6 @@ import Base from '../layouts/Base.astro';
       paintChart(curSample, curMonthly);
     });
   });
-
-  function setStreets(streets: string[]) {
-    ($('sel-street') as HTMLSelectElement).innerHTML =
-      `<option value="__all" selected>All streets</option>` +
-      streets.map((s) => `<option value="${s}">${titleCase(s)}</option>`).join('');
-  }
-  async function loadStreets() {
-    const town = ($('sel-town') as HTMLSelectElement).value;
-    const streets = await query<{ street_name: string }>(
-      `SELECT DISTINCT street_name FROM resale WHERE town='${sql(town)}' ORDER BY street_name`,
-    );
-    setStreets(streets.map((s) => s.street_name));
-  }
 
   // ---- boot: paint the default view from the precomputed snapshot, then wire filters ----
   type Snapshot = {
@@ -442,14 +426,14 @@ import Base from '../layouts/Base.astro';
     ($('sel-town') as HTMLSelectElement).innerHTML = data.towns
       .map((t) => `<option${t === data.default.town ? ' selected' : ''}>${t}</option>`)
       .join('');
-    setStreets(data.streets);
+    setStreets($('sel-street'), data.streets);
 
     // Paint immediately from JSON — no DuckDB needed for the default view.
     paintChart(data.sample, data.monthly);
 
     // Filters (and the semantic-zoom resample) go through DuckDB.
     $('sel-town').addEventListener('change', async () => {
-      await loadStreets();
+      setStreets($('sel-street'), await loadStreets(query, ($('sel-town') as HTMLSelectElement).value));
       loadRender();
     });
     $('sel-street').addEventListener('change', loadRender);
@@ -457,28 +441,6 @@ import Base from '../layouts/Base.astro';
 
     warmEngineWhenIdle();
   })();
-
-  // Boot DuckDB in the background once the default view is up, so the first filter change
-  // or zoom is snappy — without competing with first paint. Skipped under Save-Data.
-  function warmEngineWhenIdle() {
-    if ((navigator as any).connection?.saveData) return;
-    const idle: (cb: () => void) => void =
-      (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
-    const warm = () =>
-      idle(() => {
-        _db = import('../lib/db');
-        _db.then((m) => m.prefetch()).catch(() => {});
-      });
-    // This link is a clientPrerender target: while the page is only being speculatively
-    // prerendered (from a hover), don't download the ~4.7 MB DuckDB wasm — a hover
-    // shouldn't pull the engine for a page never visited. Defer the warm until the
-    // prerender is activated into a real navigation.
-    if ((document as any).prerendering) {
-      document.addEventListener('prerenderingchange', warm, { once: true });
-    } else {
-      warm();
-    }
-  }
 
   // semantic zoom: re-sample the scatter to the visible date window so zooming in reveals more detail
   async function resampleForZoom() {

--- a/web/src/pages/town-analysis.astro
+++ b/web/src/pages/town-analysis.astro
@@ -329,22 +329,23 @@ import Base from '../layouts/Base.astro';
   // a precomputed snapshot (town-analysis.json). The engine is imported lazily and only
   // booted when the visitor changes a filter (warmed on idle so that first change is
   // snappy). The query() wrapper primes the same lazy import the warm path reuses.
-  let _db: Promise<typeof import('../lib/db')> | null = null;
-  const query = async <T = any,>(sql: string): Promise<T[]> => {
-    if (!_db) _db = import('../lib/db');
-    return (await _db).query<T>(sql);
-  };
   import { money, moneyShort, psf as fpsf, titleCase } from '../lib/format';
+  import {
+    createQuery,
+    sqlEsc as sql,
+    byId as $,
+    setStreets,
+    loadStreets,
+  } from '../lib/duckdbClient';
 
+  const { query, warmEngineWhenIdle } = createQuery();
   const DEFAULT_TOWN = 'ANG MO KIO';
   const DEFAULT_FLAT = '4 ROOM';
-  const $ = (id: string) => document.getElementById(id)!;
   const BAND_COLOR: Record<string, string> = {
     above: '#fe012b',
     around: '#d98a2b',
     below: '#1f7a4d',
   };
-  const sql = (s: string) => s.replace(/'/g, "''");
 
   type Row = {
     lat: number;
@@ -480,21 +481,6 @@ import Base from '../layouts/Base.astro';
       })),
     );
     paintMap(rows, town, flat);
-  }
-
-  // Street dropdown depends on the selected town (like psf-trends). "__all" keeps
-  // every street in the town, matching the default snapshot.
-  function setStreets(streets: string[]) {
-    ($('sel-street') as HTMLSelectElement).innerHTML =
-      `<option value="__all" selected>All streets</option>` +
-      streets.map((s) => `<option value="${s}">${titleCase(s)}</option>`).join('');
-  }
-  async function loadStreets() {
-    const town = ($('sel-town') as HTMLSelectElement).value;
-    const streets = await query<{ street_name: string }>(
-      `SELECT DISTINCT street_name FROM resale WHERE town='${sql(town)}' ORDER BY street_name`,
-    );
-    setStreets(streets.map((s) => s.street_name));
   }
 
   // ---- record sales (paged, town-scoped or Singapore-wide) ----
@@ -636,7 +622,7 @@ import Base from '../layouts/Base.astro';
     ($('sel-flat') as HTMLSelectElement).innerHTML = data.flatTypes
       .map((f) => `<option${f === data.default.flat ? ' selected' : ''}>${f}</option>`)
       .join('');
-    setStreets(data.streets);
+    setStreets($('sel-street'), data.streets);
 
     // Paint immediately from JSON — no DuckDB needed for the default view.
     paintMap(data.rows, data.default.town, data.default.flat);
@@ -651,7 +637,7 @@ import Base from '../layouts/Base.astro';
     // independent, so it doesn't). The records span all flat types, so sel-flat only
     // drives the map.
     $('sel-town').addEventListener('change', async () => {
-      await loadStreets();
+      setStreets($('sel-street'), await loadStreets(query, ($('sel-town') as HTMLSelectElement).value));
       loadMap();
       if (recordScope === 'town') {
         recordPage = 0;
@@ -684,18 +670,6 @@ import Base from '../layouts/Base.astro';
 
     warmEngineWhenIdle();
   })();
-
-  // Boot DuckDB in the background once the default view is up, so the first filter
-  // change is snappy — without competing with first paint. Skipped under Save-Data.
-  function warmEngineWhenIdle() {
-    if ((navigator as any).connection?.saveData) return;
-    const idle: (cb: () => void) => void =
-      (window as any).requestIdleCallback || ((cb: () => void) => setTimeout(cb, 1500));
-    idle(() => {
-      _db = import('../lib/db');
-      _db.then((m) => m.prefetch()).catch(() => {});
-    });
-  }
 
   window.addEventListener('resize', () => {
     map.invalidateSize();


### PR DESCRIPTION
Closes #49.

The per-page client `<script>` blocks re-declared the same scaffolding. This pulls it into shared modules so there's one canonical implementation.

## Changes

**New `web/src/lib/duckdbClient.ts`**
- `createQuery()` → `{ query, prefetch, warmEngineWhenIdle }`, closing over a single lazy `import('./db')` so querying and warming share one engine and never double-download it.
- Preserves the Save-Data + `document.prerendering` speculative-prerender guards — and **adds** the prerender guard to `town-analysis` (the one page missing it), so all pages share one warm path.
- Also exports `byId`, `sqlEsc` (uses `String(s)`, the safe superset of the old variants), `setStreets(el, streets)` and `loadStreets(query, town)`.

**`web/src/lib/format.ts`**
- Adds `deltaPill(n, { threshold, digits })` → `{ cls, arrow, text }`. Threshold is parameterised (0 / 0.5 / 1 per call site); output matches the previous inline formatting byte-for-byte.

**The four interactive pages** now import these instead of re-declaring them (`byId as $` etc. to keep call sites unchanged). ~80 lines removed.

**Also:** pin `typescript` to `^5.9.3` (latest 5.x). `astro check` needs a TS version that still ships the programmatic API, which the native TS 7 compiler dropped; this makes the existing `"5"` intent explicit (resolves to the same 5.9.3).

## Verification

- Every existing DOM id and the warm/query behaviour are unchanged.
- Full Playwright suite passes **12/12**, including the regression guards called out in the issue: `prefetch.spec.ts` (landing pre-warms the engine) and `wasm-single-fetch.spec.ts` (engine wasm fetched exactly once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)