### PR TITLE
fix(web): align My Flat Insights form-card values, captions and selects

### DIFF
--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -323,6 +323,8 @@ import LeafletMap from '../components/LeafletMap.astro';
     gap: 0;
   }
   .field {
+    display: flex;
+    flex-direction: column;
     padding: 18px 22px;
     border-right: 1px solid var(--line);
     border-bottom: 1px solid var(--line);
@@ -367,7 +369,8 @@ import LeafletMap from '../components/LeafletMap.astro';
   .field .sub {
     font-size: 12.5px;
     color: var(--ink-3);
-    margin-top: 5px;
+    margin-top: auto;
+    padding-top: 5px;
   }
   .form-foot {
     display: flex;

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -323,8 +323,6 @@ import LeafletMap from '../components/LeafletMap.astro';
     gap: 0;
   }
   .field {
-    display: flex;
-    flex-direction: column;
     padding: 18px 22px;
     border-right: 1px solid var(--line);
     border-bottom: 1px solid var(--line);
@@ -341,14 +339,9 @@ import LeafletMap from '../components/LeafletMap.astro';
     color: var(--ink-3);
     margin-bottom: 9px;
   }
-  /* Values are anchored to the bottom of the cell (margin-top:auto) so that
-     across a row the differently-sized values (the 26px postal code vs the
-     17px selects) share a baseline. Their sub-labels then line up too, with a
-     uniform gap below each value. */
   .field .val {
     font-size: 17px;
     font-weight: 500;
-    margin-top: auto;
   }
   .field input,
   .field select {
@@ -361,7 +354,21 @@ import LeafletMap from '../components/LeafletMap.astro';
     color: var(--ink);
     outline: none;
     padding: 0;
-    margin-top: auto;
+  }
+  /* Every value occupies the same fixed-height box (tall enough for the 26px
+     postal code) so the differently-sized values don't change their own cell's
+     height. Because all six cells then have identical structure, the labels,
+     values and sub-labels line up across each row with uniform gaps, whatever
+     the font size. An explicit height (not just line-height) is needed because
+     <select> ignores line-height for its box height. The postal glyphs are
+     still larger; they just sit centred in the same box. */
+  .field .val,
+  .field input,
+  .field select {
+    box-sizing: border-box;
+    display: block;
+    height: 32px;
+    line-height: 32px;
   }
   .field input.big {
     font-family: var(--font-mono);

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -341,9 +341,14 @@ import LeafletMap from '../components/LeafletMap.astro';
     color: var(--ink-3);
     margin-bottom: 9px;
   }
+  /* Values are anchored to the bottom of the cell (margin-top:auto) so that
+     across a row the differently-sized values — the 26px postal code vs the
+     17px selects — share a baseline. Their sub-labels then line up too, with a
+     uniform gap below each value. */
   .field .val {
     font-size: 17px;
     font-weight: 500;
+    margin-top: auto;
   }
   .field input,
   .field select {
@@ -356,6 +361,7 @@ import LeafletMap from '../components/LeafletMap.astro';
     color: var(--ink);
     outline: none;
     padding: 0;
+    margin-top: auto;
   }
   .field input.big {
     font-family: var(--font-mono);
@@ -369,8 +375,7 @@ import LeafletMap from '../components/LeafletMap.astro';
   .field .sub {
     font-size: 12.5px;
     color: var(--ink-3);
-    margin-top: auto;
-    padding-top: 5px;
+    margin-top: 5px;
   }
   .form-foot {
     display: flex;

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -342,8 +342,8 @@ import LeafletMap from '../components/LeafletMap.astro';
     margin-bottom: 9px;
   }
   /* Values are anchored to the bottom of the cell (margin-top:auto) so that
-     across a row the differently-sized values — the 26px postal code vs the
-     17px selects — share a baseline. Their sub-labels then line up too, with a
+     across a row the differently-sized values (the 26px postal code vs the
+     17px selects) share a baseline. Their sub-labels then line up too, with a
      uniform gap below each value. */
   .field .val {
     font-size: 17px;

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -378,6 +378,20 @@ import LeafletMap from '../components/LeafletMap.astro';
   }
   .field select {
     cursor: pointer;
+    /* A native <select> renders its text with a small, browser-specific left
+       inset that padding can't remove, so the value drifts right of the label.
+       appearance:none drops the native widget (and its inset) so the value sits
+       flush-left like the inputs; the chevron is re-added as a background. This
+       is the standard pattern (cf. Bootstrap's .form-select). The stroke colour
+       is hard-coded to --ink-3 (#8c8479) because a data-URI SVG can't read a CSS
+       variable — keep it in sync if that token changes. */
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    padding-right: 18px;
+    background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='14' viewBox='0 0 10 14' fill='none' stroke='%238c8479' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M2.5 5.5 5 3l2.5 2.5'/><path d='M2.5 8.5 5 11l2.5-2.5'/></svg>")
+      no-repeat right center;
+    background-size: 10px 14px;
   }
   .field .sub {
     font-size: 12.5px;

--- a/web/tests/form-alignment.spec.ts
+++ b/web/tests/form-alignment.spec.ts
@@ -90,4 +90,19 @@ test('flat-insights form card: values and sub-labels align within each row', asy
       label('value→caption gap spread'),
     ).toBeLessThanOrEqual(TOL);
   }
+
+  // A native <select> insets its text by a browser-specific amount that bounding
+  // boxes can't see, pushing the value right of the label. The fix relies on
+  // appearance:none + zero left padding, so guard those directly.
+  const selects = await page.$$eval('.form-grid .field select', (els) =>
+    els.map((el) => {
+      const s = getComputedStyle(el);
+      return { appearance: s.appearance, paddingLeft: s.paddingLeft };
+    }),
+  );
+  expect(selects.length).toBeGreaterThan(0);
+  for (const s of selects) {
+    expect(s.appearance, 'select must drop native appearance (it insets text)').toBe('none');
+    expect(parseFloat(s.paddingLeft), 'select must be flush-left with the label').toBe(0);
+  }
 });

--- a/web/tests/form-alignment.spec.ts
+++ b/web/tests/form-alignment.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+// Guards the flat-insights form-card layout. Each field stacks label / value /
+// sub-label; the postal code renders at 26px while the other values are 17px.
+// Because the three cells in a grid row share a height (the divider lines), a
+// naive layout pushes that size difference into an uneven gap (a ragged
+// caption line or a ragged label-to-value gap). The fix gives every value the
+// same fixed-height box so all cells share one structure.
+//
+// Rather than pixel-snapshot the card (brittle across font rendering), we assert
+// the layout INVARIANTS directly from getBoundingClientRect: within each row the
+// value baselines, the caption tops, and the label-to-value gaps must all match.
+// This is deterministic and catches both failure modes described above.
+
+const TOL = 2; // px; absorbs cross-browser sub-pixel rounding, well under a visible gap
+
+type Box = { top: number; bottom: number };
+type Field = { name: string; row: number; label: Box; value: Box; sub: Box };
+
+async function readFields(page: import('@playwright/test').Page): Promise<Field[]> {
+  return page.$$eval('.form-grid .field', (fields) => {
+    const box = (el: Element | null): { top: number; bottom: number } => {
+      const b = (el as HTMLElement).getBoundingClientRect();
+      return { top: b.top, bottom: b.bottom };
+    };
+    return fields.map((f) => ({
+      name: (f.querySelector('label')?.textContent || '').trim(),
+      row: Math.round(f.getBoundingClientRect().top),
+      label: box(f.querySelector('label')),
+      value: box(f.querySelector('input, select, .val')),
+      sub: box(f.querySelector('.sub')),
+    }));
+  });
+}
+
+const spread = (xs: number[]) => Math.max(...xs) - Math.min(...xs);
+
+test('flat-insights form card: values and sub-labels align within each row', async ({ page }) => {
+  await page.goto('/my-flat-insights/');
+  await expect(page.locator('.form-grid .field').first()).toBeVisible();
+
+  // Populate every field exactly the way the page's resolve()/onFlatChange() do
+  // (select via <option>, subs via textContent, inputs via value). Injecting keeps
+  // this a hermetic LAYOUT test that asserts the CSS contract without depending on
+  // the DuckDB dataset or which postal happens to be most common.
+  await page.evaluate(() => {
+    const $ = (id: string) => document.getElementById(id) as HTMLElement;
+    ($('f-postal') as HTMLInputElement).value = '821308';
+    $('f-postal-sub').textContent = '308A Punggol Walk · Punggol';
+    $('f-flat').innerHTML = '<option>4 ROOM</option>';
+    $('f-flat-sub').textContent = 'Premium Apartment';
+    $('f-storey').innerHTML = '<option>10 TO 12</option>';
+    ($('f-area') as HTMLInputElement).value = '990';
+    $('f-area-sub').textContent = '≈ typical for this block';
+    ($('f-lease') as HTMLInputElement).value = '89';
+    $('f-lease-sub').textContent = 'Commenced 2016';
+    $('f-model').textContent = 'Premium Apartment';
+  });
+
+  const fields = await readFields(page);
+  expect(fields.length).toBeGreaterThanOrEqual(6);
+
+  // group cells into their visual rows
+  const rows = new Map<number, Field[]>();
+  for (const f of fields) {
+    const key = [...rows.keys()].find((k) => Math.abs(k - f.row) < 4) ?? f.row;
+    rows.set(key, [...(rows.get(key) ?? []), f]);
+  }
+
+  for (const [, cells] of rows) {
+    if (cells.length < 2) continue;
+    const label = (m: string) =>
+      `[row @${cells[0].row}px: ${cells.map((c) => c.name).join(', ')}] ${m}`;
+
+    // 1. value baselines share a bottom edge
+    expect(
+      spread(cells.map((c) => c.value.bottom)),
+      label('value.bottom spread'),
+    ).toBeLessThanOrEqual(TOL);
+    // 2. sub-labels line up
+    expect(spread(cells.map((c) => c.sub.top)), label('sub.top spread')).toBeLessThanOrEqual(TOL);
+    // 3. the gap between label and value is uniform (the reported "funny gap")
+    expect(
+      spread(cells.map((c) => c.value.top - c.label.bottom)),
+      label('label→value gap spread'),
+    ).toBeLessThanOrEqual(TOL);
+    // 4. the gap between value and caption is uniform
+    expect(
+      spread(cells.map((c) => c.sub.top - c.value.bottom)),
+      label('value→caption gap spread'),
+    ).toBeLessThanOrEqual(TOL);
+  }
+});


### PR DESCRIPTION
## What

On **My Flat Insights**, the form-card spacing looked off in two ways. Each field stacks label / value / sub-text in a 3-column grid.

1. The postal code renders at 26px (`.big` mono) while the other values are 17px. Because the three cells in a row must share a height (the divider lines), that size difference forced an uneven gap: top-aligning made the caption line ragged, and bottom-aligning made the gap under the FLAT TYPE / STOREY labels ragged.
2. The `<select>` values ("4 ROOM", "10 TO 12") sat indented to the right of their labels, out of line with the number inputs below them.

## Fix

**Alignment:** give every value the same fixed-height box (32px, tall enough for the 26px postal) with an explicit `height` plus `display: block`. A `<select>` ignores `line-height` for its box height, and default `inline-block` adds a stray sub-pixel, so both are pinned. All six cells then share one structure, so labels, values and captions line up per row with a uniform 9px label gap and 5px caption gap. The postal stays visually larger; it just sits centred in the same box.

**Select indent:** a native `<select>` renders its text with a small, browser-specific left inset that padding cannot remove. `appearance: none` drops the native widget (and its inset) so the value sits flush-left like the inputs, with the chevron re-added as a background SVG. This is the standard pattern (Bootstrap's `.form-select` does the same).

## Validation

Added `web/tests/form-alignment.spec.ts`, a Playwright test (the repo's existing e2e framework) that asserts the layout invariants straight from `getBoundingClientRect` rather than pixel-snapshotting, which is brittle across font rendering. Per row it checks that value baselines, caption tops, and both gap sizes match within 2px, and it guards the select fix by asserting every form select has `appearance: none` and zero left padding (the text inset is invisible to bounding boxes):

```
value.bottom spread   <= 2px
sub.top spread        <= 2px
label->value gap      <= 2px
value->caption gap    <= 2px
select: appearance == none, padding-left == 0
```

The test is hermetic (it injects the same values `resolve()` sets, so it needs no dataset) and was confirmed to fail on the pre-fix layouts and pass on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)