### PR TITLE
fix(web): keyboard focus rings + prevent iOS input zoom

### DIFF
--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -355,6 +355,14 @@ import LeafletMap from '../components/LeafletMap.astro';
     outline: none;
     padding: 0;
   }
+  /* Restore a visible focus ring for keyboard users (outline:none above removes
+     it for everyone). :focus-visible keeps it off for mouse/touch clicks. */
+  .field input:focus-visible,
+  .field select:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
   .field input.big {
     font-family: var(--font-mono);
     font-size: 26px;
@@ -729,7 +737,8 @@ import LeafletMap from '../components/LeafletMap.astro';
     border-radius: 9px;
     padding: 10px 12px;
     font-family: var(--font-mono);
-    font-size: 15px;
+    /* >=16px so iOS Safari doesn't zoom the viewport when the field is focused */
+    font-size: 16px;
     font-weight: 600;
     color: var(--ink);
     outline: none;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -527,6 +527,12 @@ footer {
   outline: none;
   max-width: 200px;
 }
+/* Keyboard focus ring for the filter selects (outline:none above hides it). */
+.field-select select:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
 
 /* ---------- pills ---------- */
 .pill {


### PR DESCRIPTION
Two small, independent form-control fixes (split out from the form-card alignment work in #54).

## 1. Missing keyboard focus indicators (a11y)

`.field input, .field select` (valuation form) and `.field-select select` (filter bars) set `outline: none` with no replacement, so keyboard users had no visible focus indicator (a WCAG 2.4.7 failure). Added `:focus-visible` rings, which stay off for mouse/touch clicks:

```css
.field input:focus-visible,
.field select:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
```

Verified in a headless browser: after keyboard focus, each control matches `:focus-visible` and renders a 2px solid outline, and the ring is visible around the focused field.

## 2. iOS zoom on the return inputs

The "Your return" inputs (`.ret-inputs input`) were `15px`. iOS Safari zooms the viewport whenever a text field under 16px is focused. Bumped to `16px`. The valuation form is already 17px, and a `<select>` opens a picker rather than zooming, so those are unaffected.

## Scope

CSS only, no markup changes. Independent of #54 (that PR touches the value-box layout; this touches focus and one font-size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)