### PR TITLE
fix(web): tidy the My Flat Insights form header and field affordances

### DIFF
--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -14,9 +14,9 @@ import LeafletMap from '../components/LeafletMap.astro';
        a second time, since the worker's instantiate fetch doesn't reuse the prefetch cache. -->
   <section class="hero">
     <div class="wrap">
-      <span class="eyebrow rise"><span class="dot"></span> New · Personalised</span>
+      <span class="eyebrow rise"><span class="dot"></span> My Flat Insights</span>
       <h1 class="title rise" style="animation-delay:.05s">
-        What's your flat<br /><em>really</em> worth?
+        What's your flat <em>really</em> worth?
       </h1>
       <p class="lede solo rise" style="animation-delay:.1s">
         Start with your postal code, and we'll value your flat against nearby transactions.
@@ -25,7 +25,7 @@ import LeafletMap from '../components/LeafletMap.astro';
       <div class="form-card rise" style="animation-delay:.16s">
         <div class="form-grid">
           <div class="field">
-            <label for="f-postal"><span class="step">1</span>Postal code</label>
+            <label for="f-postal">Postal code</label>
             <input
               id="f-postal"
               class="big"
@@ -341,13 +341,6 @@ import LeafletMap from '../components/LeafletMap.astro';
     color: var(--ink-3);
     margin-bottom: 9px;
   }
-  /* The step chip is out of flow (absolute), so the postal label keeps the same height
-     as its neighbours; the form-alignment test asserts every cell in a row shares one
-     value baseline. padding-left just reserves the space the chip overlays. */
-  .field label[for='f-postal'] {
-    position: relative;
-    padding-left: 25px;
-  }
   .field .val {
     font-size: 17px;
     font-weight: 500;
@@ -387,6 +380,11 @@ import LeafletMap from '../components/LeafletMap.astro';
     outline-offset: 2px;
     border-radius: 2px;
   }
+  /* The postal code is the field people actively type into; a heavy ring around
+     the big mono value looks jarring, so keep it unhighlighted. */
+  .field input.big:focus-visible {
+    outline: none;
+  }
   .field input.big {
     font-family: var(--font-mono);
     font-size: 26px;
@@ -410,31 +408,33 @@ import LeafletMap from '../components/LeafletMap.astro';
       no-repeat right center;
     background-size: 10px 14px;
   }
+  /* The number fields default to the browser's native up/down spinner, which
+     looks nothing like the crisp double-chevron on the selects. Drop the spinner
+     and reuse the exact same chevron so all four adjustable fields read as one
+     set (keep --ink-3 #8c8479 in sync with the select above). */
+  .field input[type='number'] {
+    -webkit-appearance: none;
+    -moz-appearance: textfield;
+    appearance: none;
+    padding-right: 18px;
+    background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='14' viewBox='0 0 10 14' fill='none' stroke='%238c8479' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M2.5 5.5 5 3l2.5 2.5'/><path d='M2.5 8.5 5 11l2.5-2.5'/></svg>")
+      no-repeat right center;
+    background-size: 10px 14px;
+  }
+  .field input[type='number']::-webkit-outer-spin-button,
+  .field input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
   .field .sub {
     font-size: 12.5px;
     color: var(--ink-3);
     margin-top: 5px;
   }
+  /* A gentle nudge toward the first action — kept subtle (muted, not red) so it
+     guides without shouting. It self-clears once a postal resolves (see JS). */
   .field .sub.cue {
-    color: var(--red-ink);
-    font-weight: 600;
-  }
-  .field label .step {
-    position: absolute;
-    left: 0;
-    top: 50%;
-    transform: translateY(-50%);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 17px;
-    height: 17px;
-    border-radius: 50%;
-    background: var(--red);
-    color: #fff;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    letter-spacing: 0;
+    color: var(--ink-2);
   }
   .form-foot {
     display: flex;

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -408,18 +408,13 @@ import LeafletMap from '../components/LeafletMap.astro';
       no-repeat right center;
     background-size: 10px 14px;
   }
-  /* The number fields default to the browser's native up/down spinner, which
-     looks nothing like the crisp double-chevron on the selects. Drop the spinner
-     and reuse the exact same chevron so all four adjustable fields read as one
-     set (keep --ink-3 #8c8479 in sync with the select above). */
+  /* Hide the browser's native up/down spinner on the number fields. A stepper
+     chevron here would only be decorative (it can't increment), so drop it and
+     let these read as plain typed values like the postal field above. */
   .field input[type='number'] {
     -webkit-appearance: none;
     -moz-appearance: textfield;
     appearance: none;
-    padding-right: 18px;
-    background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='14' viewBox='0 0 10 14' fill='none' stroke='%238c8479' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M2.5 5.5 5 3l2.5 2.5'/><path d='M2.5 8.5 5 11l2.5-2.5'/></svg>")
-      no-repeat right center;
-    background-size: 10px 14px;
   }
   .field input[type='number']::-webkit-outer-spin-button,
   .field input[type='number']::-webkit-inner-spin-button {


### PR DESCRIPTION
## What

Polish pass on the **My Flat Insights** hero + entry form.

- **Cleaner number fields** — Floor area and Remaining lease showed the browser's native up/down spinner. Hid it so they read as plain typed values like the postal field. (A custom chevron there would only be decorative since it can't step the value; the Flat type / Storey selects keep their functional dropdown chevrons.)
- **No focus box on the postal input** — dropped the focus ring on the big mono postal value; the heavy outline looked jarring while typing. Other fields keep their keyboard focus ring for accessibility.
- **Removed the red numbered "1" step chip** on the postal label and softened the "Start here · your 6-digit code" cue from bold red to muted — keeps the nudge without shouting.
- **Hero header** — renamed the eyebrow to "My Flat Insights" to match the section labels on the other pages (Market Overview, Explore by Town, Price per Square Foot), and reflowed the title onto a single line.

## Verification

- `astro check`, `eslint`, `prettier` all clean (pre-commit + manual).
- Rendered the page in a local dev server and screenshotted the hero/form to confirm each change visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)