### PR TITLE
fix(web): make remaining lease drive the flat valuation

### DIFF
--- a/web/src/lib/lease.test.ts
+++ b/web/src/lib/lease.test.ts
@@ -1,0 +1,67 @@
+import { test, expect, describe } from 'bun:test';
+import { SLA_LEASEHOLD, leaseFactor, leaseAdjustment } from './lease';
+
+describe('SLA_LEASEHOLD table', () => {
+  test('covers whole years 0..99', () => {
+    expect(SLA_LEASEHOLD.length).toBe(100);
+    expect(SLA_LEASEHOLD[0]).toBe(0);
+  });
+  test('matches the published SLA anchor values', () => {
+    expect(SLA_LEASEHOLD[99]).toBe(96.0);
+    expect(SLA_LEASEHOLD[60]).toBe(80.0);
+    expect(SLA_LEASEHOLD[30]).toBe(60.0);
+    expect(SLA_LEASEHOLD[5]).toBe(17.1);
+  });
+  test('is monotonically increasing (value never rises as lease shortens)', () => {
+    for (let i = 1; i < SLA_LEASEHOLD.length; i++) {
+      expect(SLA_LEASEHOLD[i]).toBeGreaterThan(SLA_LEASEHOLD[i - 1]);
+    }
+  });
+});
+
+describe('leaseFactor', () => {
+  test('returns the table value on whole years', () => {
+    expect(leaseFactor(99)).toBe(96.0);
+    expect(leaseFactor(60)).toBe(80.0);
+  });
+  test('interpolates linearly between years', () => {
+    // between 60 (80.0) and 61 (80.6): halfway is 80.3
+    expect(leaseFactor(60.5)).toBeCloseTo(80.3, 6);
+  });
+  test('clamps out-of-range inputs to [0, 99]', () => {
+    expect(leaseFactor(-10)).toBe(0);
+    expect(leaseFactor(150)).toBe(96.0);
+  });
+});
+
+describe('leaseAdjustment', () => {
+  test('same lease as the comps is a no-op', () => {
+    const a = leaseAdjustment(95, 95);
+    expect(a.known).toBe(true);
+    expect(a.factor).toBe(1);
+    expect(a.pct).toBe(0);
+  });
+
+  test('a longer lease than the comps lifts the estimate', () => {
+    const a = leaseAdjustment(99, 95);
+    expect(a.factor).toBeGreaterThan(1);
+    expect(a.pct).toBeCloseTo((leaseFactor(99) / leaseFactor(95) - 1) * 100, 10);
+  });
+
+  test('a much shorter lease meaningfully discounts the estimate', () => {
+    const a = leaseAdjustment(40, 95);
+    expect(a.factor).toBeLessThan(1);
+    expect(a.pct).toBeLessThan(-20); // ~-28%
+  });
+
+  test('scaling a PSF by the factor round-trips against the table ratio', () => {
+    const psf = 650;
+    const a = leaseAdjustment(60, 95);
+    expect(psf * a.factor).toBeCloseTo((psf * leaseFactor(60)) / leaseFactor(95), 6);
+  });
+
+  test('missing or non-positive lease -> not known, factor 1 (UI shows n/a)', () => {
+    expect(leaseAdjustment(0, 95)).toEqual({ factor: 1, pct: 0, known: false });
+    expect(leaseAdjustment(60, 0)).toEqual({ factor: 1, pct: 0, known: false });
+  });
+});

--- a/web/src/lib/lease.ts
+++ b/web/src/lib/lease.ts
@@ -1,0 +1,50 @@
+// SLA Leasehold Relativity Table — leasehold value as a percentage of freehold
+// by remaining lease term (Source: Singapore Land Authority). Used to normalise
+// comparable sales to a flat's own remaining lease so a longer/shorter lease
+// moves the valuation. Index = whole years remaining (0..99).
+// prettier-ignore
+export const SLA_LEASEHOLD = [
+  0, 3.8, 7.5, 10.9, 14.1, 17.1, 19.9, 22.7, 25.2, 27.7, 30.0,
+  32.2, 34.3, 36.3, 38.2, 40.0, 41.8, 43.4, 45.0, 46.6, 48.0,
+  49.5, 50.8, 52.1, 53.4, 54.6, 55.8, 56.9, 58.0, 59.0, 60.0,
+  61.0, 61.9, 62.8, 63.7, 64.6, 65.4, 66.2, 67.0, 67.7, 68.5,
+  69.2, 69.8, 70.5, 71.2, 71.8, 72.4, 73.0, 73.6, 74.1, 74.7,
+  75.2, 75.7, 76.2, 76.7, 77.3, 77.9, 78.5, 79.0, 79.5, 80.0,
+  80.6, 81.2, 81.8, 82.4, 83.0, 83.6, 84.2, 84.5, 85.4, 86.0,
+  86.5, 87.0, 87.5, 88.0, 88.5, 89.0, 89.5, 90.0, 90.5, 91.0,
+  91.4, 91.8, 92.2, 92.6, 92.9, 93.3, 93.6, 94.0, 94.3, 94.6,
+  94.8, 95.0, 95.2, 95.4, 95.6, 95.7, 95.8, 95.9, 96.0,
+];
+
+/**
+ * Leasehold value as a percentage of freehold for a given remaining lease,
+ * read off the SLA table. Years are clamped to [0, 99] and interpolated
+ * linearly for fractional inputs (a median comp lease need not be a whole year).
+ */
+export function leaseFactor(years: number): number {
+  const y = Math.max(0, Math.min(99, years));
+  const lo = Math.floor(y),
+    hi = Math.ceil(y);
+  return SLA_LEASEHOLD[lo] + (SLA_LEASEHOLD[hi] - SLA_LEASEHOLD[lo]) * (y - lo);
+}
+
+export interface LeaseAdjustment {
+  /** Multiplicative factor to apply to comp PSF; 1 when not computable. */
+  factor: number;
+  /** The factor as a percentage delta, e.g. -16.3. */
+  pct: number;
+  /** False when either lease is missing/non-positive, so the UI shows n/a. */
+  known: boolean;
+}
+
+/**
+ * How much a flat's own remaining lease shifts its value versus the comps it is
+ * priced against. Returns the SLA-table ratio leaseFactor(rem)/leaseFactor(comp):
+ * a longer lease than the comps lifts the estimate, a shorter one discounts it.
+ * Falls back to a no-op factor of 1 when either lease is unknown.
+ */
+export function leaseAdjustment(remYears: number, compLease: number): LeaseAdjustment {
+  const known = remYears > 0 && compLease > 0;
+  const factor = known ? leaseFactor(remYears) / leaseFactor(compLease) : 1;
+  return { factor, pct: (factor - 1) * 100, known };
+}

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -119,6 +119,14 @@ import LeafletMap from '../components/LeafletMap.astro';
             ><span class="v" id="vs-storey">—</span>
           </div>
           <div class="vs-row">
+            <span class="k"
+              ><Term term="Lease adjustment" end
+                >How much your remaining lease shifts the estimate versus the comps' typical lease,
+                using the SLA Leasehold Table.</Term
+              ></span
+            ><span class="v" id="vs-lease">—</span>
+          </div>
+          <div class="vs-row">
             <span class="k">Your floor area</span><span class="v" id="vs-area">—</span>
           </div>
           <div class="conf">
@@ -130,8 +138,8 @@ import LeafletMap from '../components/LeafletMap.astro';
           </div>
           <p class="disclaimer">
             Indicative estimate for guidance only — not a valuation for HDB, bank or CPF purposes.
-            Adjusted for storey band; not for exact lease or unit condition. Based on registered
-            resale transactions from data.gov.sg.
+            Adjusted for storey band and remaining lease (SLA Leasehold Table); not for unit
+            condition. Based on registered resale transactions from data.gov.sg.
           </p>
         </div>
       </div>
@@ -1002,6 +1010,29 @@ import LeafletMap from '../components/LeafletMap.astro';
       hi = Math.ceil(i);
     return sorted[lo] + (sorted[hi] - sorted[lo]) * (i - lo);
   };
+  // SLA Leasehold Relativity Table — leasehold value as % of freehold by
+  // remaining lease term (Source: Singapore Land Authority). Used to normalise
+  // comps to the flat's own remaining lease. Index = whole years remaining
+  // (0..99); we linearly interpolate for fractional years.
+  // prettier-ignore
+  const SLA_LEASEHOLD = [
+    0, 3.8, 7.5, 10.9, 14.1, 17.1, 19.9, 22.7, 25.2, 27.7, 30.0,
+    32.2, 34.3, 36.3, 38.2, 40.0, 41.8, 43.4, 45.0, 46.6, 48.0,
+    49.5, 50.8, 52.1, 53.4, 54.6, 55.8, 56.9, 58.0, 59.0, 60.0,
+    61.0, 61.9, 62.8, 63.7, 64.6, 65.4, 66.2, 67.0, 67.7, 68.5,
+    69.2, 69.8, 70.5, 71.2, 71.8, 72.4, 73.0, 73.6, 74.1, 74.7,
+    75.2, 75.7, 76.2, 76.7, 77.3, 77.9, 78.5, 79.0, 79.5, 80.0,
+    80.6, 81.2, 81.8, 82.4, 83.0, 83.6, 84.2, 84.5, 85.4, 86.0,
+    86.5, 87.0, 87.5, 88.0, 88.5, 89.0, 89.5, 90.0, 90.5, 91.0,
+    91.4, 91.8, 92.2, 92.6, 92.9, 93.3, 93.6, 94.0, 94.3, 94.6,
+    94.8, 95.0, 95.2, 95.4, 95.6, 95.7, 95.8, 95.9, 96.0,
+  ];
+  const leaseFactor = (years: number) => {
+    const y = Math.max(0, Math.min(99, years));
+    const lo = Math.floor(y),
+      hi = Math.ceil(y);
+    return SLA_LEASEHOLD[lo] + (SLA_LEASEHOLD[hi] - SLA_LEASEHOLD[lo]) * (y - lo);
+  };
   // ---- Leaflet map ----
   const map = L.map('ins-map', { scrollWheelZoom: false }).setView([1.3521, 103.8198], 12);
   L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
@@ -1383,10 +1414,17 @@ import LeafletMap from '../components/LeafletMap.astro';
     const useStorey = nearStorey.length >= 5; // only adjust when the band has enough sales
     const basis = useStorey ? nearStorey : comps;
     const psfs = basis.map((c) => c.psf).sort((a, b) => a - b);
-    const medPsf = med(psfs),
-      q25 = quantile(psfs, 0.25),
-      q75 = quantile(psfs, 0.75);
-    const storeyAdjPct = baseMedPsf ? (medPsf / baseMedPsf - 1) * 100 : 0;
+    const rawMedPsf = med(psfs);
+    const storeyAdjPct = baseMedPsf ? (rawMedPsf / baseMedPsf - 1) * 100 : 0;
+    // lease adjustment — normalise the comps' typical remaining lease to this
+    // flat's via the SLA Leasehold Table, so a longer/shorter lease moves the estimate.
+    const compLease = med(basis.map((c) => c.lease).filter((l) => l > 0));
+    const leaseKnown = rem > 0 && compLease > 0;
+    const leaseAdj = leaseKnown ? leaseFactor(rem) / leaseFactor(compLease) : 1;
+    const leaseAdjPct = (leaseAdj - 1) * 100;
+    const medPsf = rawMedPsf * leaseAdj,
+      q25 = quantile(psfs, 0.25) * leaseAdj,
+      q75 = quantile(psfs, 0.75) * leaseAdj;
     const estimate = medPsf * area,
       low = q25 * area,
       high = q75 * area;
@@ -1413,6 +1451,9 @@ import LeafletMap from '../components/LeafletMap.astro';
     $('vs-storey').textContent = useStorey
       ? `${storeyAdjPct >= 0 ? '+' : ''}${storeyAdjPct.toFixed(1)}% · ${storey}`
       : 'n/a — too few';
+    $('vs-lease').textContent = leaseKnown
+      ? `${leaseAdjPct >= 0 ? '+' : ''}${leaseAdjPct.toFixed(1)}% · ${rem} yr vs ${Math.round(compLease)} yr`
+      : 'n/a';
     $('conf-label').textContent = confLabel;
     $('conf-bars').innerHTML = [0, 1, 2, 3]
       .map((i) => `<i class="${i < confBars ? 'on' : ''}"></i>`)

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -982,6 +982,7 @@ import LeafletMap from '../components/LeafletMap.astro';
   } from '../lib/echartsTheme';
   import { money, moneyShort, psf as fpsf, titleCase, deltaPill } from '../lib/format';
   import { reformatWithCaret, parsePrice, computeReturns } from '../lib/returns';
+  import { leaseAdjustment } from '../lib/lease';
 
   const NOW_YEAR = new Date().getFullYear();
 
@@ -1009,29 +1010,6 @@ import LeafletMap from '../components/LeafletMap.astro';
       lo = Math.floor(i),
       hi = Math.ceil(i);
     return sorted[lo] + (sorted[hi] - sorted[lo]) * (i - lo);
-  };
-  // SLA Leasehold Relativity Table — leasehold value as % of freehold by
-  // remaining lease term (Source: Singapore Land Authority). Used to normalise
-  // comps to the flat's own remaining lease. Index = whole years remaining
-  // (0..99); we linearly interpolate for fractional years.
-  // prettier-ignore
-  const SLA_LEASEHOLD = [
-    0, 3.8, 7.5, 10.9, 14.1, 17.1, 19.9, 22.7, 25.2, 27.7, 30.0,
-    32.2, 34.3, 36.3, 38.2, 40.0, 41.8, 43.4, 45.0, 46.6, 48.0,
-    49.5, 50.8, 52.1, 53.4, 54.6, 55.8, 56.9, 58.0, 59.0, 60.0,
-    61.0, 61.9, 62.8, 63.7, 64.6, 65.4, 66.2, 67.0, 67.7, 68.5,
-    69.2, 69.8, 70.5, 71.2, 71.8, 72.4, 73.0, 73.6, 74.1, 74.7,
-    75.2, 75.7, 76.2, 76.7, 77.3, 77.9, 78.5, 79.0, 79.5, 80.0,
-    80.6, 81.2, 81.8, 82.4, 83.0, 83.6, 84.2, 84.5, 85.4, 86.0,
-    86.5, 87.0, 87.5, 88.0, 88.5, 89.0, 89.5, 90.0, 90.5, 91.0,
-    91.4, 91.8, 92.2, 92.6, 92.9, 93.3, 93.6, 94.0, 94.3, 94.6,
-    94.8, 95.0, 95.2, 95.4, 95.6, 95.7, 95.8, 95.9, 96.0,
-  ];
-  const leaseFactor = (years: number) => {
-    const y = Math.max(0, Math.min(99, years));
-    const lo = Math.floor(y),
-      hi = Math.ceil(y);
-    return SLA_LEASEHOLD[lo] + (SLA_LEASEHOLD[hi] - SLA_LEASEHOLD[lo]) * (y - lo);
   };
   // ---- Leaflet map ----
   const map = L.map('ins-map', { scrollWheelZoom: false }).setView([1.3521, 103.8198], 12);
@@ -1419,9 +1397,11 @@ import LeafletMap from '../components/LeafletMap.astro';
     // lease adjustment — normalise the comps' typical remaining lease to this
     // flat's via the SLA Leasehold Table, so a longer/shorter lease moves the estimate.
     const compLease = med(basis.map((c) => c.lease).filter((l) => l > 0));
-    const leaseKnown = rem > 0 && compLease > 0;
-    const leaseAdj = leaseKnown ? leaseFactor(rem) / leaseFactor(compLease) : 1;
-    const leaseAdjPct = (leaseAdj - 1) * 100;
+    const {
+      factor: leaseAdj,
+      pct: leaseAdjPct,
+      known: leaseKnown,
+    } = leaseAdjustment(rem, compLease);
     const medPsf = rawMedPsf * leaseAdj,
       q25 = quantile(psfs, 0.25) * leaseAdj,
       q75 = quantile(psfs, 0.75) * leaseAdj;


### PR DESCRIPTION
## Problem

On **My Flat Insights**, the *Remaining lease (years)* input was cosmetic for the valuation. Changing it re-ran `compute()`, but `rem` only fed display-only widgets (the lease-position bar, CPF/loan flags, the marker on the lease-decay chart, and the "your flat" comps row). It never entered the PSF/estimate pipeline, so the headline value, likely range, PSF and price benchmarks, and distribution never moved. The disclaimer even admitted it: *"not adjusted for exact lease."*

## Fix

Lease now drives the valuation via the official **SLA Leasehold Relativity Table** (value as % of freehold by remaining term; e.g. 99y = 96.0%, 60y = 80.0%, 30y = 60.0%, 5y = 17.1%).

- Added the full year-by-year SLA table (`SLA_LEASEHOLD`, 1→99) plus a `leaseFactor()` lookup with interpolation for fractional years.
- In `compute()`, normalise the comps' **median** remaining lease to the flat's own lease — `leaseFactor(rem) / leaseFactor(compLease)` — and scale `medPsf`/`q25`/`q75`. The estimate, range, PSF benchmark and price benchmark all now shift with lease.
- Storey adjustment is computed **before** the lease scale, so the two adjustments stay independent.
- Surfaced a **Lease adjustment** row in the "How we got here" panel (e.g. `-16.3% · 60 yr vs 95 yr`) and updated the disclaimer.

Directional sanity check: same lease → 0%, 99 vs 95y → +0.4%, 60 vs 95y → −16.3%, 40 vs 95y → −28.3% (front-loaded decay, as expected).

## Verification

- `astro check` — 0 errors
- `eslint` — 0 errors (pre-existing `any` warnings only)
- `prettier --check` — clean
- Unit-checked the table (100 entries; anchors match SLA) and the adjustment ratio logic.

Source: [Unpacking Singapore's Leasehold Relativity Table (IRER, Table 1, Source: SLA)](https://www.gssinst.org/irer/wp-content/uploads/2025/10/vol28_no3_4-MS24070401-Unpacking-Singapores-Leasehold-Ti.pdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)