### PR TITLE
feat(web): affordability & mortgage calculator (section 01.5)

### DIFF
--- a/web/src/lib/mortgage.test.ts
+++ b/web/src/lib/mortgage.test.ts
@@ -1,0 +1,112 @@
+import { test, expect, describe } from 'bun:test';
+import {
+  LOAN_RULES,
+  MSR,
+  TDSR,
+  monthlyInstalment,
+  maxTenure,
+  computeMortgage,
+  sensitivityTable,
+} from './mortgage';
+
+describe('monthlyInstalment', () => {
+  test('matches the closed-form amortisation formula', () => {
+    const P = 487500,
+      annual = 0.026,
+      years = 25;
+    const r = annual / 12,
+      n = years * 12,
+      f = Math.pow(1 + r, n);
+    expect(monthlyInstalment(P, annual, years)).toBeCloseTo((P * r * f) / (f - 1), 6);
+  });
+  test('a 0% rate is straight-line principal / months', () => {
+    expect(monthlyInstalment(120000, 0, 10)).toBeCloseTo(1000, 6); // 120k / 120mo
+  });
+  test('a higher rate or shorter tenure raises the instalment', () => {
+    const base = monthlyInstalment(487500, 0.026, 25);
+    expect(monthlyInstalment(487500, 0.035, 25)).toBeGreaterThan(base); // higher rate
+    expect(monthlyInstalment(487500, 0.026, 20)).toBeGreaterThan(base); // shorter tenure
+  });
+  test('non-positive principal or tenure -> 0', () => {
+    expect(monthlyInstalment(0, 0.026, 25)).toBe(0);
+    expect(monthlyInstalment(-1, 0.026, 25)).toBe(0);
+    expect(monthlyInstalment(487500, 0.026, 0)).toBe(0);
+  });
+});
+
+describe('maxTenure', () => {
+  test('clamps to the flat’s remaining lease when it is the tighter limit', () => {
+    expect(maxTenure('hdb', 18)).toBe(18); // below the 25y HDB cap
+    expect(maxTenure('bank', 22)).toBe(22); // below the 30y bank cap
+  });
+  test('uses the loan-type cap when the lease is longer', () => {
+    expect(maxTenure('hdb', 78)).toBe(25);
+    expect(maxTenure('bank', 78)).toBe(30);
+  });
+  test('never returns below the 5-year floor', () => {
+    expect(maxTenure('hdb', 2)).toBe(5);
+  });
+  test('unknown lease (<= 0) falls back to the loan-type cap', () => {
+    expect(maxTenure('hdb', 0)).toBe(25);
+    expect(maxTenure('bank', -1)).toBe(30);
+  });
+});
+
+describe('computeMortgage', () => {
+  test('splits a $650k HDB purchase into loan and downpayment by LTV', () => {
+    const m = computeMortgage({ price: 650000, loanType: 'hdb', tenureYears: 25 });
+    expect(m.loan).toBe(487500); // 75% LTV
+    expect(m.downpayment).toBe(162500); // 25%
+    expect(m.downpaymentPct).toBeCloseTo(0.25, 10);
+    expect(m.rate).toBe(LOAN_RULES.hdb.rate);
+  });
+
+  test('HDB downpayment can be fully CPF (0 minimum cash)', () => {
+    const m = computeMortgage({ price: 650000, loanType: 'hdb', tenureYears: 25 });
+    expect(m.cash).toBe(0);
+    expect(m.cpf).toBe(162500);
+  });
+
+  test('bank loan carries a 5% minimum cash floor, rest CPF', () => {
+    const m = computeMortgage({ price: 650000, loanType: 'bank', tenureYears: 25 });
+    expect(m.cash).toBe(32500); // 5% of price
+    expect(m.cpf).toBe(130000); // remaining 20%
+    expect(m.cash + m.cpf).toBeCloseTo(m.downpayment, 6);
+  });
+
+  test('total interest is total repayments minus the loan, and is positive', () => {
+    const m = computeMortgage({ price: 650000, loanType: 'hdb', tenureYears: 25 });
+    expect(m.totalPaid).toBeCloseTo(m.instalment * 300, 6);
+    expect(m.totalInterest).toBeCloseTo(m.totalPaid - m.loan, 6);
+    expect(m.totalInterest).toBeGreaterThan(0);
+  });
+
+  test('minimum income is MSR-bound (instalment / 30%) when there is no other debt', () => {
+    const m = computeMortgage({ price: 650000, loanType: 'hdb', tenureYears: 25 });
+    expect(m.minIncomeMsr).toBeCloseTo(m.instalment / MSR, 6);
+    expect(m.minIncomeTdsr).toBeCloseTo(m.instalment / TDSR, 6);
+    // MSR (30%) is tighter than TDSR (55%) -> it binds.
+    expect(m.minIncome).toBeCloseTo(m.minIncomeMsr, 6);
+    expect(m.minIncomeMsr).toBeGreaterThan(m.minIncomeTdsr);
+  });
+
+  test('an explicit rate override is used in place of the rule rate', () => {
+    const m = computeMortgage({ price: 650000, loanType: 'hdb', tenureYears: 25, rate: 0.04 });
+    expect(m.rate).toBe(0.04);
+    expect(m.instalment).toBeCloseTo(monthlyInstalment(m.loan, 0.04, 25), 6);
+  });
+});
+
+describe('sensitivityTable', () => {
+  test('is a tenure × rate grid off a single LTV-derived loan amount', () => {
+    const rows = sensitivityTable(650000, 'hdb');
+    expect(rows.map((r) => r.tenure)).toEqual([20, 25, 30]);
+    const loan = 650000 * LOAN_RULES.hdb.ltv;
+    expect(rows[1].instalments[0]).toBeCloseTo(monthlyInstalment(loan, 0.026, 25), 6);
+  });
+  test('instalment falls as tenure lengthens within a rate column', () => {
+    const rows = sensitivityTable(650000, 'hdb');
+    expect(rows[0].instalments[0]).toBeGreaterThan(rows[1].instalments[0]); // 20y > 25y
+    expect(rows[1].instalments[0]).toBeGreaterThan(rows[2].instalments[0]); // 25y > 30y
+  });
+});

--- a/web/src/lib/mortgage.ts
+++ b/web/src/lib/mortgage.ts
@@ -1,0 +1,150 @@
+// Affordability & mortgage maths for "My Flat Insights" (section 01.5). Pure and
+// DOM-free so it can be unit-tested (mirrors returns.ts / lease.ts). All Singapore
+// loan rules that change over time live in LOAN_RULES / MSR / TDSR below, alongside
+// RULES_AS_OF, so there is a single place to update them — nothing here is advice.
+
+export type LoanType = 'hdb' | 'bank';
+
+export interface LoanRule {
+  /** Short label for the segmented control, e.g. "HDB". */
+  label: string;
+  /** Illustrative annual interest rate (e.g. 0.026 = 2.6%). */
+  rate: number;
+  /** Maximum loan-to-value ratio (e.g. 0.75 = up to 75% financed). */
+  ltv: number;
+  /** Minimum share of the price that must be paid in cash (rest may be CPF OA). */
+  minCashPct: number;
+  /** Maximum loan tenure in years for this loan type. */
+  maxTenureYears: number;
+}
+
+// Rules as commonly applied to a resale HDB flat. Illustrative — treat as a guide,
+// not a formal assessment. Update these together and bump RULES_AS_OF when they move.
+export const LOAN_RULES: Record<LoanType, LoanRule> = {
+  hdb: { label: 'HDB', rate: 0.026, ltv: 0.75, minCashPct: 0, maxTenureYears: 25 },
+  bank: { label: 'Bank', rate: 0.035, ltv: 0.75, minCashPct: 0.05, maxTenureYears: 30 },
+};
+
+/** Mortgage Servicing Ratio cap — monthly instalment ≤ 30% of gross income (HDB flats & ECs). */
+export const MSR = 0.3;
+/** Total Debt Servicing Ratio cap — all monthly debt ≤ 55% of gross income. */
+export const TDSR = 0.55;
+/** Human-readable "rules current as of" stamp shown in the UI disclaimer. */
+export const RULES_AS_OF = 'July 2026';
+
+/** Tenures and reference rates shown in the sensitivity table. */
+export const SENSITIVITY_TENURES = [20, 25, 30] as const;
+export const SENSITIVITY_RATES = [0.026, 0.035, 0.04] as const;
+
+/**
+ * Standard amortising monthly instalment for a `principal` borrowed at `annualRate`
+ * over `years`. Uses M = P·r·(1+r)^n / ((1+r)^n − 1); handles a 0% rate (straight-line)
+ * and returns 0 for a non-positive principal or tenure.
+ */
+export function monthlyInstalment(principal: number, annualRate: number, years: number): number {
+  if (principal <= 0 || years <= 0) return 0;
+  const n = years * 12;
+  const r = annualRate / 12;
+  if (r === 0) return principal / n;
+  const f = Math.pow(1 + r, n);
+  return (principal * r * f) / (f - 1);
+}
+
+/** The longest tenure allowed for `loanType`, further capped so it does not exceed the
+ *  flat's remaining lease (and never below 5 years). remainingLease ≤ 0 means "unknown"
+ *  and only the loan-type cap applies. */
+export function maxTenure(loanType: LoanType, remainingLease: number): number {
+  const cap = LOAN_RULES[loanType].maxTenureYears;
+  if (remainingLease > 0) return Math.max(5, Math.min(cap, Math.floor(remainingLease)));
+  return cap;
+}
+
+export interface MortgageInput {
+  price: number;
+  loanType: LoanType;
+  tenureYears: number;
+  /** Optional override of the rule rate (e.g. the sensitivity table); defaults to the rule. */
+  rate?: number;
+}
+
+export interface MortgageResult {
+  price: number;
+  rate: number;
+  ltv: number;
+  loan: number; // amount financed
+  downpayment: number; // price − loan
+  downpaymentPct: number; // downpayment / price
+  cash: number; // minimum cash portion of the downpayment
+  cpf: number; // CPF OA portion (downpayment − cash)
+  cashPct: number; // cash / price
+  instalment: number; // monthly repayment
+  annualRepayment: number; // instalment × 12
+  totalPaid: number; // instalment × months
+  totalInterest: number; // totalPaid − loan
+  minIncomeMsr: number; // income that puts the instalment at the MSR cap
+  minIncomeTdsr: number; // income that puts total debt at the TDSR cap
+  minIncome: number; // binding minimum household income (max of the two)
+}
+
+/** Full affordability breakdown for one price / loan-type / tenure combination. */
+export function computeMortgage({
+  price,
+  loanType,
+  tenureYears,
+  rate,
+}: MortgageInput): MortgageResult {
+  const rule = LOAN_RULES[loanType];
+  const usedRate = rate ?? rule.rate;
+  const loan = Math.max(0, price * rule.ltv);
+  const downpayment = price - loan;
+  const cash = price * rule.minCashPct;
+  const cpf = Math.max(0, downpayment - cash);
+
+  const instalment = monthlyInstalment(loan, usedRate, tenureYears);
+  const months = tenureYears * 12;
+  const totalPaid = instalment * months;
+  const totalInterest = Math.max(0, totalPaid - loan);
+
+  // MSR binds the instalment alone; TDSR binds all debt (here just the mortgage, so
+  // MSR is the tighter of the two whenever there is no other debt). The household needs
+  // whichever income clears both caps.
+  const minIncomeMsr = MSR > 0 ? instalment / MSR : 0;
+  const minIncomeTdsr = TDSR > 0 ? instalment / TDSR : 0;
+
+  return {
+    price,
+    rate: usedRate,
+    ltv: rule.ltv,
+    loan,
+    downpayment,
+    downpaymentPct: price > 0 ? downpayment / price : 0,
+    cash,
+    cpf,
+    cashPct: rule.minCashPct,
+    instalment,
+    annualRepayment: instalment * 12,
+    totalPaid,
+    totalInterest,
+    minIncomeMsr,
+    minIncomeTdsr,
+    minIncome: Math.max(minIncomeMsr, minIncomeTdsr),
+  };
+}
+
+/**
+ * Monthly instalment grid for the sensitivity table: one row per tenure, one cell per
+ * rate. The loan amount is fixed by the price and the loan type's LTV, so only the rate
+ * and tenure vary across the grid.
+ */
+export function sensitivityTable(
+  price: number,
+  loanType: LoanType,
+  tenures: readonly number[] = SENSITIVITY_TENURES,
+  rates: readonly number[] = SENSITIVITY_RATES,
+): { tenure: number; instalments: number[] }[] {
+  const loan = Math.max(0, price * LOAN_RULES[loanType].ltv);
+  return tenures.map((tenure) => ({
+    tenure,
+    instalments: rates.map((r) => monthlyInstalment(loan, r, tenure)),
+  }));
+}

--- a/web/src/pages/my-flat-insights.astro
+++ b/web/src/pages/my-flat-insights.astro
@@ -171,6 +171,132 @@ import LeafletMap from '../components/LeafletMap.astro';
         <div class="ps-foot" id="ps-foot"></div>
       </div>
 
+      <!-- 01.5 AFFORDABILITY & MORTGAGE -->
+      <SecHead num="01.5" title="What it takes to buy this flat" hintId="afford-hint">
+        Turns the estimate into the numbers you actually decide on — the monthly instalment, the
+        cash-plus-CPF downpayment, and the household income needed under Singapore's MSR and TDSR
+        limits.
+      </SecHead>
+
+      <div class="card chart-card afford-card">
+        <div class="calc">
+          <!-- controls -->
+          <div class="afford-controls">
+            <div class="chart-title afford-controls-title">Your numbers</div>
+
+            <div class="ctl">
+              <label for="m-price">Purchase price</label>
+              <span class="val mono" id="m-price-val">—</span>
+              <input
+                id="m-price"
+                type="range"
+                min="300000"
+                max="1200000"
+                value="650000"
+                step="10000"
+              />
+              <div class="field-note">
+                Pre-filled from the valuation above; drag to test other prices.
+              </div>
+            </div>
+
+            <div class="ctl">
+              <label for="m-tenure">Loan tenure</label>
+              <span class="val mono" id="m-tenure-val">—</span>
+              <input id="m-tenure" type="range" min="5" max="25" value="25" step="1" />
+              <div class="field-note" id="m-tenure-note">
+                Capped by the loan type and the flat's remaining lease.
+              </div>
+            </div>
+
+            <div class="ctl">
+              <label>Loan type / rate</label>
+              <div class="seg" id="m-loantype" role="group" aria-label="Loan type">
+                <button type="button" class="on" data-loan="hdb">HDB · 2.6%</button>
+                <button type="button" data-loan="bank">Bank · 3.5%</button>
+              </div>
+              <div class="field-note">
+                HDB concessionary rate vs an illustrative bank rate. Rates are indicative.
+              </div>
+            </div>
+
+            <div class="ctl">
+              <label for="m-lease">Remaining lease</label>
+              <span class="val mono" id="m-lease-val">—</span>
+              <input id="m-lease" type="range" min="30" max="99" value="78" step="1" />
+              <div class="field-note">
+                Resolved from the flat's lease start; short leases restrict tenure and CPF usage.
+              </div>
+            </div>
+          </div>
+
+          <!-- results -->
+          <div class="afford-results">
+            <div class="headline">
+              <div class="cap">Estimated monthly instalment</div>
+              <div class="big mono" id="m-instalment">—<span class="per">/mo</span></div>
+              <div class="sub" id="m-instalment-sub">&nbsp;</div>
+            </div>
+
+            <div class="kpis afford-kpis">
+              <div class="kpi">
+                <div class="cap">Downpayment</div>
+                <div class="num mono" id="m-downpayment">
+                  —<small id="m-downpayment-sub">&nbsp;</small>
+                </div>
+              </div>
+              <div class="kpi">
+                <div class="cap">Min household income</div>
+                <div class="num mono" id="m-income">—<small>per month, MSR-bound</small></div>
+              </div>
+              <div class="kpi">
+                <div class="cap">Total interest</div>
+                <div class="num mono" id="m-interest">
+                  —<small id="m-interest-sub">&nbsp;</small>
+                </div>
+              </div>
+            </div>
+
+            <div class="afford-split">
+              <div class="chart-title afford-split-title">Downpayment: cash vs CPF</div>
+              <div class="chart-sub" id="m-split-sub">&nbsp;</div>
+              <div class="bar">
+                <i id="m-split-cash" style="width:0;background:var(--red)"></i>
+                <i id="m-split-cpf" style="width:100%;background:var(--good)"></i>
+              </div>
+              <div class="lg" id="m-split-legend"></div>
+            </div>
+
+            <div class="afford-split">
+              <div class="chart-title afford-split-title afford-income-head">
+                Income check <span class="pill up" id="m-income-pill">within limits</span>
+              </div>
+              <div class="chart-sub" id="m-income-sub">&nbsp;</div>
+              <div class="lg">
+                <span
+                  ><span class="pill up afford-ratio-pill">MSR 30%</span> mortgage servicing ratio met</span
+                >
+                <span
+                  ><span class="pill up afford-ratio-pill">TDSR 55%</span> total debt servicing ratio
+                  met</span
+                >
+              </div>
+            </div>
+
+            <div>
+              <div class="chart-title afford-split-title">Sensitivity: monthly instalment</div>
+              <table class="sens">
+                <thead>
+                  <tr><th>Tenure</th><th>2.6% (HDB)</th><th>3.5% (bank)</th><th>4.0%</th></tr>
+                </thead>
+                <tbody id="m-sens-body"></tbody>
+              </table>
+              <div class="afford-disclaimer" id="m-disclaimer">&nbsp;</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- 02 PRICE TRAJECTORY -->
       <SecHead num="02" title="Price trajectory" hintId="traj-hint">
         How your flat type has moved here over the years.
@@ -956,6 +1082,246 @@ import LeafletMap from '../components/LeafletMap.astro';
     border-color: var(--red);
     background: var(--red-wash);
   }
+  /* ---- 01.5 affordability & mortgage calculator ---- */
+  .afford-card {
+    margin-top: 18px;
+    padding: 20px 22px;
+  }
+  .calc {
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    gap: 22px;
+  }
+  .afford-controls {
+    display: grid;
+    gap: 18px;
+    align-content: start;
+  }
+  .afford-controls-title {
+    margin-bottom: 2px;
+  }
+  .ctl label {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-bottom: 7px;
+  }
+  .ctl .val {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    font-size: 17px;
+    color: var(--ink);
+  }
+  .ctl input[type='range'] {
+    width: 100%;
+    accent-color: var(--red);
+    margin-top: 8px;
+  }
+  .field-note {
+    font-size: 11.5px;
+    color: var(--ink-3);
+    margin-top: 6px;
+  }
+  .field-note :global(code) {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    background: #efe8da;
+    padding: 1px 5px;
+    border-radius: 5px;
+  }
+  .seg {
+    display: inline-flex;
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--paper-2);
+  }
+  .seg button {
+    font: inherit;
+    font-size: 13px;
+    padding: 7px 13px;
+    border: 0;
+    background: transparent;
+    color: var(--ink-2);
+    cursor: pointer;
+  }
+  .seg button.on {
+    background: var(--red);
+    color: #fff;
+    font-weight: 600;
+  }
+  .afford-results {
+    display: grid;
+    gap: 16px;
+    align-content: start;
+  }
+  .headline {
+    background: linear-gradient(180deg, var(--paper-2), var(--red-wash));
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 20px 22px;
+  }
+  .headline .cap {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+  .headline .big {
+    font-weight: 600;
+    font-size: 40px;
+    letter-spacing: -0.02em;
+    color: var(--red-ink);
+    line-height: 1.05;
+    margin-top: 4px;
+  }
+  /* .per is injected into #m-instalment via innerHTML, so it needs :global to be styled */
+  .headline .big :global(.per) {
+    font-size: 18px;
+  }
+  .headline .sub {
+    font-size: 13.5px;
+    color: var(--ink-2);
+    margin-top: 6px;
+  }
+  .headline .sub :global(b) {
+    color: var(--ink);
+  }
+  .afford-kpis {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
+  .afford-kpis .kpi {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--paper-2);
+    padding: 13px 14px;
+  }
+  .afford-kpis .kpi .cap {
+    font-size: 11.5px;
+    color: var(--ink-3);
+  }
+  .afford-kpis .kpi .num {
+    font-weight: 600;
+    font-size: 20px;
+    margin-top: 3px;
+  }
+  /* the <small> caption is injected via innerHTML — :global so the scope attr isn't required */
+  .afford-kpis .kpi .num :global(small) {
+    display: block;
+    font-family: var(--font-sans);
+    font-weight: 400;
+    font-size: 11.5px;
+    color: var(--ink-3);
+  }
+  .afford-split {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--paper-2);
+    padding: 15px 16px;
+  }
+  .afford-split-title {
+    font-size: 14px;
+    margin-bottom: 2px;
+  }
+  .afford-income-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+  }
+  .afford-split .chart-sub {
+    margin: 2px 0 4px;
+  }
+  .afford-split .bar {
+    display: flex;
+    height: 18px;
+    border-radius: 6px;
+    overflow: hidden;
+    margin: 10px 0 8px;
+  }
+  .afford-split .bar i {
+    display: block;
+    height: 100%;
+    transition: width 0.18s ease;
+  }
+  .afford-split .lg {
+    display: flex;
+    gap: 16px;
+    font-size: 12px;
+    color: var(--ink-2);
+    flex-wrap: wrap;
+  }
+  /* legend spans are injected via innerHTML for the cash/CPF split, so :global them */
+  .afford-split .lg :global(span) {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .afford-split .lg :global(em) {
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+    font-style: normal;
+    display: inline-block;
+  }
+  .afford-ratio-pill {
+    font-size: 11px;
+  }
+  table.sens {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+    margin-top: 4px;
+  }
+  table.sens th,
+  table.sens td {
+    padding: 8px 10px;
+    text-align: right;
+    border-bottom: 1px solid var(--line);
+  }
+  table.sens th:first-child,
+  table.sens td:first-child {
+    text-align: left;
+    color: var(--ink-2);
+  }
+  table.sens thead th {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    font-weight: 600;
+  }
+  /* :global — sensitivity rows are injected via innerHTML */
+  :global(table.sens td.mono) {
+    font-family: var(--font-mono);
+    font-feature-settings: 'tnum' 1;
+  }
+  :global(table.sens tr.hi td) {
+    background: var(--red-wash);
+  }
+  .afford-disclaimer {
+    font-size: 12px;
+    color: var(--ink-3);
+    margin-top: 8px;
+  }
+  @media (max-width: 820px) {
+    .calc {
+      grid-template-columns: 1fr;
+    }
+  }
+  @media (max-width: 560px) {
+    .afford-kpis {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
   @media (max-width: 900px) {
     .form-grid {
       grid-template-columns: 1fr 1fr;
@@ -1139,6 +1505,17 @@ import LeafletMap from '../components/LeafletMap.astro';
   import { money, moneyShort, psf as fpsf, titleCase, deltaPill } from '../lib/format';
   import { reformatWithCaret, parsePrice, computeReturns } from '../lib/returns';
   import { leaseAdjustment } from '../lib/lease';
+  import {
+    LOAN_RULES,
+    MSR,
+    RULES_AS_OF,
+    SENSITIVITY_RATES,
+    SENSITIVITY_TENURES,
+    computeMortgage,
+    maxTenure,
+    sensitivityTable,
+    type LoanType,
+  } from '../lib/mortgage';
 
   const NOW_YEAR = new Date().getFullYear();
 
@@ -1504,6 +1881,108 @@ import LeafletMap from '../components/LeafletMap.astro';
       .join('');
   }
 
+  // ===== 01.5 · affordability & mortgage (pure client-side; see lib/mortgage.ts) =====
+  let loanType: LoanType = 'hdb';
+  // "2.6%" / "4%" — drop a trailing ".0" so whole rates read cleanly.
+  const rateLabel = (r: number) => (r * 100).toFixed(1).replace(/\.0$/, '') + '%';
+
+  // Re-read the four controls and repaint the whole panel. No worker round-trip: this is
+  // the standard amortisation formula plus the SG rule constants applied to local inputs.
+  function updateMortgage() {
+    const price = Number(($('m-price') as HTMLInputElement).value) || 0;
+    const rem = Number(($('m-lease') as HTMLInputElement).value) || 0;
+
+    // Tenure is capped by the loan type and the flat's remaining lease; clamp the slider's
+    // max (and current value) before reading it, so the range can never exceed the rules.
+    const tenureEl = $('m-tenure') as HTMLInputElement;
+    const cap = maxTenure(loanType, rem);
+    tenureEl.max = String(cap);
+    let tenure = Number(tenureEl.value) || cap;
+    if (tenure > cap) {
+      tenure = cap;
+      tenureEl.value = String(cap);
+    }
+
+    $('m-price-val').textContent = money(price);
+    $('m-tenure-val').textContent = `${tenure} year${tenure === 1 ? '' : 's'}`;
+    $('m-lease-val').textContent = `${rem} years`;
+
+    const rule = LOAN_RULES[loanType];
+    const m = computeMortgage({ price, loanType, tenureYears: tenure });
+
+    // headline instalment
+    $('m-instalment').innerHTML = `${money(m.instalment)}<span class="per">/mo</span>`;
+    $('m-instalment-sub').innerHTML =
+      `On a ${money(m.loan)} loan (${Math.round(m.ltv * 100)}% LTV) over ${tenure} years at ${rateLabel(m.rate)}. ` +
+      `That is roughly <b>${money(m.annualRepayment)} a year</b> in repayments.`;
+
+    // KPIs
+    $('m-downpayment').innerHTML =
+      `${money(m.downpayment)}<small>${Math.round(m.downpaymentPct * 100)}% of price</small>`;
+    $('m-income').innerHTML = `${money(m.minIncome)}<small>per month, MSR-bound</small>`;
+    $('m-interest').innerHTML = `${money(m.totalInterest)}<small>over ${tenure} years</small>`;
+
+    // downpayment split — cash vs CPF
+    const dp = m.downpayment || 1;
+    const cashW = Math.round((m.cash / dp) * 100);
+    ($('m-split-cash') as HTMLElement).style.width = cashW + '%';
+    ($('m-split-cpf') as HTMLElement).style.width = 100 - cashW + '%';
+    const cashFloor = Math.round(rule.minCashPct * 100);
+    $('m-split-sub').textContent =
+      rule.minCashPct > 0
+        ? `${rule.label} loan needs at least ${cashFloor}% of the price in cash; the rest can come from your CPF Ordinary Account.`
+        : `An ${rule.label} loan downpayment can be paid entirely from your CPF Ordinary Account — cash is optional.`;
+    $('m-split-legend').innerHTML =
+      `<span><em style="background:var(--red)"></em> Cash · ${money(m.cash)}${rule.minCashPct > 0 ? ` (min ${cashFloor}%)` : ''}</span>` +
+      `<span><em style="background:var(--good)"></em> CPF OA · ${money(m.cpf)}</span>`;
+
+    // income check
+    $('m-income-sub').textContent =
+      `At ${money(m.minIncome)} household income, the instalment is ${Math.round(MSR * 100)}% of gross income — right at the MSR cap for HDB flats — and well within the 55% TDSR.`;
+
+    // sensitivity: highlight the row nearest the chosen tenure, and the current rate's cell
+    const rateCol = SENSITIVITY_RATES.findIndex((r) => Math.abs(r - m.rate) < 1e-9);
+    const nearestTenure = SENSITIVITY_TENURES.reduce((a, b) =>
+      Math.abs(b - tenure) < Math.abs(a - tenure) ? b : a,
+    );
+    $('m-sens-body').innerHTML = sensitivityTable(price, loanType)
+      .map((row) => {
+        const hi = row.tenure === nearestTenure;
+        const cells = row.instalments
+          .map(
+            (v, i) =>
+              `<td class="mono"${i === rateCol && hi ? ' style="color:var(--red-ink)"' : ''}>${money(v)}</td>`,
+          )
+          .join('');
+        const overCap = row.tenure > cap;
+        return `<tr class="${hi ? 'hi' : ''}"><td>${row.tenure} years${overCap ? '*' : ''}</td>${cells}</tr>`;
+      })
+      .join('');
+    const capped = SENSITIVITY_TENURES.some((t) => t > cap);
+    $('m-disclaimer').textContent =
+      (capped
+        ? `* Longer tenures shown for comparison; your ${rule.label} loan caps at ${cap} years given the loan type and remaining lease. `
+        : '') +
+      `Illustrative only, not financial advice. MSR (30%), TDSR (55%), LTV and CPF rules are current as of ${RULES_AS_OF} and change over time.`;
+  }
+
+  // Pre-fill the calculator from a finished valuation: snap the price to the slider step,
+  // point the lease slider at the flat's remaining lease, then repaint.
+  function seedMortgage(estimate: number, rem: number) {
+    const priceEl = $('m-price') as HTMLInputElement;
+    const min = Number(priceEl.min),
+      max = Number(priceEl.max),
+      step = Number(priceEl.step) || 1;
+    priceEl.value = String(Math.round(Math.min(max, Math.max(min, estimate)) / step) * step);
+    if (rem > 0) {
+      const leaseEl = $('m-lease') as HTMLInputElement;
+      const lmin = Number(leaseEl.min),
+        lmax = Number(leaseEl.max);
+      leaseEl.value = String(Math.min(lmax, Math.max(lmin, Math.round(rem))));
+    }
+    updateMortgage();
+  }
+
   // ---- compute valuation + benchmarks + comparables ----
   async function compute() {
     const flat = ($('f-flat') as HTMLSelectElement).value;
@@ -1684,6 +2163,9 @@ import LeafletMap from '../components/LeafletMap.astro';
     // 04 · lease thresholds (client-side, from remaining lease)
     renderLeaseFlags(rem);
 
+    // 01.5 · affordability — pre-fill the calculator from this valuation + remaining lease
+    seedMortgage(estimate, rem);
+
     // 02/04 · trajectory + lease-decay curves came from the same worker round-trip above
     // (they need wider history than the comps window).
     const traj = trajectory;
@@ -1801,6 +2283,23 @@ import LeafletMap from '../components/LeafletMap.astro';
     renderReturns();
   });
   $('r-year').addEventListener('input', renderReturns);
+
+  // Affordability calculator recomputes locally on every control change (no worker).
+  ['m-price', 'm-tenure', 'm-lease'].forEach((id) =>
+    $(id).addEventListener('input', updateMortgage),
+  );
+  document.querySelectorAll<HTMLButtonElement>('#m-loantype button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      loanType = btn.dataset.loan as LoanType;
+      document
+        .querySelectorAll('#m-loantype button')
+        .forEach((b) => b.classList.toggle('on', b === btn));
+      updateMortgage();
+    });
+  });
+  // Render once with the default inputs so the panel reads sensibly before any valuation.
+  updateMortgage();
+
   $('get-insights').addEventListener('click', async () => {
     const cur = parseInt(($('f-postal') as HTMLInputElement).value, 10);
     // re-resolve only if the postal changed (avoid clobbering the user's edited fields)


### PR DESCRIPTION
## What & why

Valuation answers *"what is this flat worth"*; this new section answers the natural follow-up, *"can I actually buy it"*. It turns the estimate into the numbers people decide on: the **monthly instalment**, the **cash-plus-CPF downpayment**, and the **household income** needed under Singapore's MSR/TDSR limits.

Sits as **section 01.5** in My Flat Insights, between the valuation hero (01) and price trajectory (02).

## How

Pure client-side arithmetic — no DuckDB/worker query. Standard amortisation plus the SG loan rules, fed by the existing `currentEstimate` and resolved remaining lease already computed in `compute()`.

- **`web/src/lib/mortgage.ts`** — pure, DOM-free math mirroring `returns.ts` / `lease.ts`:
  - `monthlyInstalment()` (handles 0% rate / zero principal), `computeMortgage()`, `maxTenure()` (caps by loan type **and** remaining lease), `sensitivityTable()`.
  - All rate / LTV / MSR / TDSR / cash-floor constants live in one `LOAN_RULES` block with a `RULES_AS_OF` stamp — single place to update when the rules move.
- **`web/src/lib/mortgage.test.ts`** — 16 unit tests.
- **`my-flat-insights.astro`** — the section markup + scoped styles; pre-fills from the valuation on each `compute()`, recomputes locally on control changes (no worker round-trip).

## Rules note

Uses **accurate current SG rules** rather than the wireframe's illustrative placeholders (the wireframe flagged its rules as "for wireframe purposes only"). HDB loan downpayment can be fully CPF (0 min cash); bank loan carries a 5% cash floor. Figures are internally consistent (e.g. $2,212/mo → $7,372 min income at the 30% MSR cap). Copy keeps the same "not financial advice" disclaimer tone as the valuation.

## Verification

- `bun run build` — clean (7 pages)
- `bun test src` — 87/87 pass
- `eslint` — 0 errors · `prettier` — formatted
- Screenshotted the rendered panel in HDB and Bank modes (below); no console errors; sliders, loan toggle, tenure clamping, and table highlighting all behave.

### HDB loan (default)
_All-CPF downpayment, 25-year cap, 25y/2.6% row highlighted._

### Bank loan
_5% cash segment shown, tenure cap raised to 30, 30y/3.5% cell highlighted to match the headline._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
