### PR TITLE
test(web): make recent-transactions address check drift-resilient

### DIFF
--- a/web/tests/recent-transactions.spec.ts
+++ b/web/tests/recent-transactions.spec.ts
@@ -15,9 +15,15 @@ test('default page renders from JSON with block letters uppercased, data file bl
   await expect(page.locator('#tbody-recent tr')).toHaveCount(20, { timeout: 20_000 });
   await expect(page.locator('#recent-foot')).toContainText('Showing 1–20 of');
 
-  // Block + lane letter suffixes stay uppercase; the rest is title-cased.
-  const firstAddr = page.locator('#tbody-recent tr').first().locator('td').nth(2);
-  await expect(firstAddr).toHaveText('138A Lor 1A Toa Payoh');
+  // Block + lane letter suffixes stay uppercase (311c -> 311C); the rest is title-cased.
+  // Asserted as an invariant over every visible address rather than a pinned newest sale,
+  // which drifts each time the scheduled dataset auto-update refreshes the release: no
+  // letter ever directly follows a digit in lower case, and at least one address carries an
+  // uppercased block/lane suffix (so the transform provably fired, not just absent in data).
+  const addrs = await page.locator('#tbody-recent tr td:nth-child(3)').allTextContents();
+  expect(addrs).toHaveLength(20);
+  for (const a of addrs) expect(a).not.toMatch(/\d[a-z]/);
+  expect(addrs.some((a) => /\d[A-Z]/.test(a))).toBe(true);
 
   // Prev disabled on page 1; Next enabled.
   await expect(page.locator('#rec-prev')).toBeDisabled();


### PR DESCRIPTION
## Why

The `recent-transactions.spec.ts` "block letters uppercased" test pinned the **newest sale's** address (`138A Lor 1A Toa Payoh`) as an exact string. The scheduled **Auto-update** job refreshes the dataset release, and once a newer transaction takes the top row the assertion breaks — with no code change. It started failing after the 2026-07-21 auto-update (newest sale is now `273B Bishan St 24`), turning CI red on unrelated PRs (surfaced on #70).

## What

Replace the pinned-value check with an **invariant over every visible address** that still proves the intended `titleCase` behaviour ("311c -> 311C"):

- No address ever has a lowercase letter directly following a digit (`/\d[a-z]/`) — block/lane suffixes are uppercased.
- At least one address carries an uppercased block/lane suffix (`/\d[A-Z]/`), so the transform provably fired rather than being vacuously absent from the data.

This holds regardless of which sale is newest, so it survives future auto-updates.

## Verification

- Logic checked directly against `titleCase` (src/lib/format.ts) with representative addresses incl. the old and new newest sales, plus a **negative control**: a title-caser missing the digit-suffix rule is still caught by the invariant.
- `bunx tsc --noEmit` clean; eslint clean on the changed file.
- The locator (`#tbody-recent tr td:nth-child(3)`) is a broadening of the existing, already-passing first-row locator (3rd cell = `titleCase(r.address)`, index.astro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)